### PR TITLE
Fix issue with version checker not running

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@v4.1.0
         with:
           go-version: '1.21'
+          cache: false
 
       - name: Setup crane
         uses: imjasonh/setup-crane@v0.3


### PR DESCRIPTION
The version updater workflows stopped working at [run #23](https://github.com/spiffe/helm-charts/actions/runs/5923605140)

Errror: `Restore cache failed: Dependencies file is not found in /home/runner/work/helm-charts/helm-charts. Supported file pattern: go.sum`

Open ticket with setup-go and this was what they said to do: https://github.com/actions/setup-go/issues/427#issuecomment-1731969319