### PR TITLE
Fix failing Tornjak ingress port

### DIFF
--- a/charts/spire/charts/spire-server/templates/tornjak-ingress.yaml
+++ b/charts/spire/charts/spire-server/templates/tornjak-ingress.yaml
@@ -12,5 +12,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ include "spire-lib.ingress-spec" (dict "ingress" .Values.tornjak.ingress "svcName" (include "spire-tornjak.servicename" .) "port" "tornjak-srv-http") | nindent 2 }}
+  {{ include "spire-lib.ingress-spec" (dict "ingress" .Values.tornjak.ingress "svcName" (include "spire-tornjak.servicename" .) "port" .Values.tornjak.service.ports.http) | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Deployment fails with error:

```
helm.go:84: [debug] error validating "": error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0].backend.service.port.number): invalid type for io.k8s.api.networking.v1.ServiceBackendPort.number: got "string", expected "integer"
```

Setting a correct value for the Tornjak ingress port
