### PR TITLE
Bump spire Helm Chart version from 0.13.1 to 0.13.2

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "1.7.4"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

Note: As this is a patch release we will make a cherry-picked release using a followup PR targetering the release branch. Will cherrypick the following commits into this patch release + the commit bumping this version number.

**Changes in this release**

* dd87bc0 Bump spire versions to 1.7.4 (#35)
* d3091a8 Fix spire-server configmap UpstreamAuthority/aws_pca and KeyManager/a… (#489)