### PR TITLE
Update to SPIRE 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Unless otherwise noted in an application chart README, the following dependencie
 
 | Dependency | Supported Versions |
 |:-----------|:-------------------|
-| SPIRE      | `1.6.x`, `1.7.x`   |
+| SPIRE      | `1.8.2`            |
 | Helm       | `3.x`              |
 | Kubernetes | `1.22+`            |
 

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
 version: 0.13.2
-appVersion: "1.7.4"
+appVersion: "1.8.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
@@ -3,7 +3,7 @@ name: spiffe-oidc-discovery-provider
 description: A Helm chart to install the SPIFFE OIDC discovery provider.
 type: application
 version: 0.1.0
-appVersion: "1.7.4"
+appVersion: "1.8.2"
 keywords: ["spiffe", "oidc"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:

--- a/charts/spire/charts/spire-agent/Chart.yaml
+++ b/charts/spire/charts/spire-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-agent
 description: A Helm chart to install the SPIRE agent.
 type: application
 version: 0.1.0
-appVersion: "1.7.4"
+appVersion: "1.8.2"
 keywords: ["spiffe", "spire-agent"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:

--- a/charts/spire/charts/spire-server/Chart.yaml
+++ b/charts/spire/charts/spire-server/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-server
 description: A Helm chart to install the SPIRE server.
 type: application
 version: 0.1.0
-appVersion: "1.7.4"
+appVersion: "1.8.2"
 keywords: ["spiffe", "spire-server", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
 sources:


### PR DESCRIPTION
Updates to SPIRE 1.8.2. Looking throught https://github.com/spiffe/spire/issues/2670 it mentions backwards compatibility. If no profile is specified it imples `profile "https_spiffe" {}`.

fixes #12 
fixes #25 