### PR TITLE
Bump spire Helm Chart version from 0.13.2 to 0.14.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.13.2
+version: 0.14.0
 appVersion: "1.8.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> **Note**: **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

**Changes in this release**

* a01cdc9 Production test don't cleanup flag (#44)
* 56445c4 Spire controller manager upgrade (#8)
* 6635512 Fix Tornjak HTTPS ingress port (#39)
* 78ba615 Update to SPIRE 1.8.2 (#40)
* 2644e4b Bump test chart dependencies (#38)
* 5cb3c6d Bump helm.sh/helm/v3 from 3.13.0 to 3.13.1 in /tests (#37)
* 42bb8cf Bump spire Helm Chart version from 0.13.1 to 0.13.2
* dd87bc0 Bump spire versions to 1.7.4 (#35)
* fdba5d0 Bump spire Helm Chart version from 0.13.0 to 0.13.1
* 0e41a7d Fix failing Tornjak ingress port (#28)
* df1abf6 Bump to spire 1.7.3 (#31)
* 69a20e3 Merge pull request #29 from spiffe/tornjak-version
* 3036a41 Switch to version v1.4.0
* da49059 Update Tornjak image version
* 0fa43a5 Add plugin support to the spire agent (#22)
* c5c5320 Bump github.com/onsi/ginkgo/v2 from 2.12.1 to 2.13.0 in /tests (#27)
* afba33f Add spire agent experimental flags (#26)
* 1107278 Bump test chart dependencies
* 03ff618 Add Tornjak ingress (#16)
* 8f1bfc1 Merge pull request #23 from spiffe/examples-doc
* cd386eb Merge branch 'main' into examples-doc
* 12937db Update Example README
* 06d6690 Bump test chart dependencies (#20)
* 8aca48f Push the changes that update-tags creates (#19)
* a6cb397 Exit code from diff indicating changes should not block commit. (#17)
* ebfa518 Update FAQ from repo switch (#15)
* c23e6cb Fix issue with version checker not running
* 51c20b1 Bump actions/checkout from 4.0.0 to 4.1.0 (#9)
* 21db1e4 Add a test to ensure upgrades work (#6)
* f86648f Bump github.com/onsi/gomega from 1.27.10 to 1.28.0 in /tests
* babd677 Bump helm.sh/helm/v3 from 3.12.3 to 3.13.0 in /tests
* 45187fe Add back CODE-OF-CONDUCT
* 50825d9 Deny production runs of example.org trust domains (#229)
* 712a0f6 Bump actions/checkout from 4.0.0 to 4.1.0
* f04bdc3 Add support for experimental flags (#492)
* 7cdae92 Bump github.com/onsi/ginkgo/v2 from 2.12.0 to 2.12.1 in /tests (#490)
* d3091a8 Fix spire-server configmap UpstreamAuthority/aws_pca and KeyManager/a… (#489)
* 7a96175 Remove developer-guy as a CODEOWNER
