### PR TITLE
Add missing no cleanup flags to example tests

### DIFF
--- a/examples/external-mysql/run-tests.sh
+++ b/examples/external-mysql/run-tests.sh
@@ -12,11 +12,24 @@ source "${SCRIPTPATH}/../../.github/scripts/parse-versions.sh"
 # shellcheck source=/dev/null
 source "${TESTDIR}/common.sh"
 
+CLEANUP=1
+
+for i in "$@"; do
+  case $i in
+    -c)
+      CLEANUP=0
+      shift # past argument=value
+      ;;
+  esac
+done
+
 teardown() {
-  helm uninstall --namespace "spire-server" spire 2>/dev/null || true
-  helm uninstall --namespace mysql mysql 2>/dev/null || true
-  kubectl delete ns spire-server 2>/dev/null || true
-  kubectl delete ns spire-system 2>/dev/null || true
+  if [ "${CLEANUP}" -eq 1 ]; then
+    helm uninstall --namespace "spire-server" spire 2>/dev/null || true
+    helm uninstall --namespace mysql mysql 2>/dev/null || true
+    kubectl delete ns spire-server 2>/dev/null || true
+    kubectl delete ns spire-system 2>/dev/null || true
+  fi
 }
 
 trap 'trap - SIGTERM && teardown' SIGINT SIGTERM EXIT

--- a/examples/external-postgresql/run-tests.sh
+++ b/examples/external-postgresql/run-tests.sh
@@ -12,11 +12,24 @@ source "${SCRIPTPATH}/../../.github/scripts/parse-versions.sh"
 # shellcheck source=/dev/null
 source "${TESTDIR}/common.sh"
 
+CLEANUP=1
+
+for i in "$@"; do
+  case $i in
+    -c)
+      CLEANUP=0
+      shift # past argument=value
+      ;;
+  esac
+done
+
 teardown() {
-  helm uninstall --namespace "spire-server" spire 2>/dev/null || true
-  helm uninstall --namespace "spire-server" postgresql 2>/dev/null || true
-  kubectl delete ns spire-server 2>/dev/null || true
-  kubectl delete ns spire-system 2>/dev/null || true
+  if [ "${CLEANUP}" -eq 1 ]; then
+    helm uninstall --namespace "spire-server" spire 2>/dev/null || true
+    helm uninstall --namespace "spire-server" postgresql 2>/dev/null || true
+    kubectl delete ns spire-server 2>/dev/null || true
+    kubectl delete ns spire-system 2>/dev/null || true
+  fi
 }
 
 trap 'trap - SIGTERM && teardown' SIGINT SIGTERM EXIT

--- a/examples/nested/run-tests.sh
+++ b/examples/nested/run-tests.sh
@@ -12,13 +12,26 @@ source "${SCRIPTPATH}/../../.github/scripts/parse-versions.sh"
 # shellcheck source=/dev/null
 source "${TESTDIR}/common.sh"
 
-teardown() {
-  helm uninstall --namespace spire-server spire 2>/dev/null || true
-  kubectl delete ns spire-server 2>/dev/null || true
-  kubectl delete ns spire-system 2>/dev/null || true
+CLEANUP=1
 
-  helm uninstall --namespace mysql spire-root-server 2>/dev/null || true
-  kubectl delete ns spire-root-server 2>/dev/null || true
+for i in "$@"; do
+  case $i in
+    -c)
+      CLEANUP=0
+      shift # past argument=value
+      ;;
+  esac
+done
+
+teardown() {
+  if [ "${CLEANUP}" -eq 1 ]; then
+    helm uninstall --namespace spire-server spire 2>/dev/null || true
+    kubectl delete ns spire-server 2>/dev/null || true
+    kubectl delete ns spire-system 2>/dev/null || true
+
+    helm uninstall --namespace mysql spire-root-server 2>/dev/null || true
+    kubectl delete ns spire-root-server 2>/dev/null || true
+  fi
 }
 
 trap 'trap - SIGTERM && teardown' SIGINT SIGTERM EXIT

--- a/examples/tornjak/run-tests.sh
+++ b/examples/tornjak/run-tests.sh
@@ -12,9 +12,22 @@ source "${TESTDIR}/common.sh"
 helm_install=(helm upgrade --install --create-namespace)
 ns=spire-system
 
+CLEANUP=1
+
+for i in "$@"; do
+  case $i in
+    -c)
+      CLEANUP=0
+      shift # past argument=value
+      ;;
+  esac
+done
+
 teardown() {
-  helm uninstall --namespace "${ns}" spire 2>/dev/null || true
-  kubectl delete ns "${ns}" 2>/dev/null || true
+  if [ "${CLEANUP}" -eq 1 ]; then
+    helm uninstall --namespace "${ns}" spire 2>/dev/null || true
+    kubectl delete ns "${ns}" 2>/dev/null || true
+  fi
 }
 
 trap 'trap - SIGTERM && teardown' SIGINT SIGTERM EXIT


### PR DESCRIPTION
Make the rest of the tests have the same no cleanup flag that the production test has. This will be used in the future to ensure upgrading those features doesn't break.