### PR TITLE
Documentation cleanup

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/Chart.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "0.2.3"
 keywords: ["spiffe", "csi-driver"]
-home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
+home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:
-  - https://github.com/spiffe/helm-charts/tree/main/charts/spire
+  - https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 icon: https://spiffe.io/img/logos/spire/icon/color/spire-icon-color.png
 maintainers:
   - name: marcofranssen

--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -4,11 +4,7 @@
 
 A Helm chart to install the SPIFFE CSI driver.
 
-**Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
-
-> [!Note]
-> The recommended version is `0.2.3` to support arm64 nodes. If running with any
-> prior version to `0.2.3` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+**Homepage:** <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Maintainers
 
@@ -21,7 +17,7 @@ A Helm chart to install the SPIFFE CSI driver.
 
 ## Source Code
 
-* <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
+* <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 <!-- The parameters section is generated using helm-docs.sh and should not be edited by hand. -->
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "1.8.4"
 keywords: ["spiffe", "oidc"]
-home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
+home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:
-  - https://github.com/spiffe/helm-charts/tree/main/charts/spire
+  - https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 icon: https://spiffe.io/img/logos/spire/icon/color/spire-icon-color.png
 maintainers:
   - name: marcofranssen

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/README.md
@@ -4,12 +4,7 @@
 
 A Helm chart to install the SPIFFE OIDC discovery provider.
 
-**Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
-
-> [!Note]
-> Minimum Spire version is `1.5.3`.
-> The recommended version is `1.6.0` to support arm64 nodes. If running with any
-> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+**Homepage:** <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Maintainers
 
@@ -22,7 +17,7 @@ A Helm chart to install the SPIFFE OIDC discovery provider.
 
 ## Source Code
 
-* <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
+* <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 <!-- The parameters section is generated using helm-docs.sh and should not be edited by hand. -->
 

--- a/charts/spire/charts/spire-agent/Chart.yaml
+++ b/charts/spire/charts/spire-agent/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "1.8.4"
 keywords: ["spiffe", "spire-agent"]
-home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
+home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:
-  - https://github.com/spiffe/helm-charts/tree/main/charts/spire
+  - https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 icon: https://spiffe.io/img/logos/spire/icon/color/spire-icon-color.png
 maintainers:
   - name: marcofranssen

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -4,12 +4,7 @@
 
 A Helm chart to install the SPIRE agent.
 
-**Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
-
-> [!Note]
-> Minimum Spire version is `1.5.3`.
-> The recommended version is `1.6.0` to support arm64 nodes. If running with any
-> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+**Homepage:** <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Maintainers
 
@@ -22,7 +17,7 @@ A Helm chart to install the SPIRE agent.
 
 ## Source Code
 
-* <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
+* <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 <!-- The parameters section is generated using helm-docs.sh and should not be edited by hand. -->
 

--- a/charts/spire/charts/spire-server/Chart.yaml
+++ b/charts/spire/charts/spire-server/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "1.8.4"
 keywords: ["spiffe", "spire-server", "spire-controller-manager"]
-home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
+home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:
-  - https://github.com/spiffe/helm-charts/tree/main/charts/spire
+  - https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 icon: https://spiffe.io/img/logos/spire/icon/color/spire-icon-color.png
 maintainers:
   - name: marcofranssen

--- a/charts/spire/charts/spire-server/README.md
+++ b/charts/spire/charts/spire-server/README.md
@@ -4,15 +4,7 @@
 
 A Helm chart to install the SPIRE server.
 
-**Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
-
-> [!Note]
-> Minimum Spire version is `1.5.3`.
-> The recommended version is `1.6.0` to support arm64 nodes. If running with any
-> prior version to `1.6.0` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
->
-> The recommended spire-controller-manager version is `0.2.2` to support arm64 nodes. If running with any
-> prior version to `0.2.2` you have to use a `nodeSelector` to limit to `kubernetes.io/arch: amd64`.
+**Homepage:** <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Maintainers
 
@@ -25,7 +17,7 @@ A Helm chart to install the SPIRE server.
 
 ## Source Code
 
-* <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
+* <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Tornjak
 

--- a/charts/spire/charts/tornjak-frontend/Chart.yaml
+++ b/charts/spire/charts/tornjak-frontend/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Tornjak frontend
 type: application
 version: 0.1.0
 appVersion: "v1.4.0"
-home: https://github.com/spiffe/helm-charts/tree/main/charts/spire
+home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
 sources:
   - https://github.com/spiffe/tornjak
 icon: https://raw.githubusercontent.com/spiffe/tornjak/main/logos/logo%2Btornjak.2132x1291.png

--- a/charts/spire/charts/tornjak-frontend/README.md
+++ b/charts/spire/charts/tornjak-frontend/README.md
@@ -5,7 +5,7 @@
 
 A Helm chart to deploy Tornjak frontend
 
-**Homepage:** <https://github.com/spiffe/helm-charts/tree/main/charts/spire>
+**Homepage:** <https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire>
 
 ## Version support
 
@@ -16,8 +16,6 @@ A Helm chart to deploy Tornjak frontend
 
 | Dependency | Supported Versions |
 |:-----------|:-------------------|
-| SPIRE      | `1.5.3+`, `1.6.x`  |
-| Tornjak    | `1.0.x`            |
 | Helm       | `3.x`              |
 
 ## Tornjak


### PR DESCRIPTION
Fix links to the repo after move. Remove references to other versions of images we don't support.