### PR TITLE
Fix typo ClusterSPIFFEID for workloadTSelectoremplates

### DIFF
--- a/charts/spire/charts/spire-server/templates/controller-manager-cluster-ids.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-cluster-ids.yaml
@@ -25,7 +25,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .identities.workloadSelectorTemplates }}
-  workloadTSelectoremplates:
+  workloadSelectorTemplates:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .identities.ttl }}


### PR DESCRIPTION
I found a small typo in the ClusterSPIFFEID spec and this small change will fix it.