### PR TITLE
Consolidate all the examples to a common relative path

### DIFF
--- a/examples/external-mysql/README.md
+++ b/examples/external-mysql/README.md
@@ -15,7 +15,7 @@ Next, edit values.yaml with your settings. Check it into your git repo if using 
 Then, deploy the chart pointing at your mysql instance like so:
 
 ```shell
-helm upgrade --install --namespace spire-server spire charts/spire -f values.yaml --set "spire-server.dataStore.sql.password=${DBPW}"
+helm upgrade --install --namespace spire-server spire charts/spire -f examples/external-mysql/values.yaml --set "spire-server.dataStore.sql.password=${DBPW}"
 ```
 
 See the [production example](../production) for production recommendations.

--- a/examples/external-postgresql/README.md
+++ b/examples/external-postgresql/README.md
@@ -15,7 +15,7 @@ Next, edit values.yaml with your settings. Check it into your git repo if using 
 Then, deploy the chart pointing at your postgresql instance like so:
 
 ```shell
-helm upgrade --install --namespace spire-server spire charts/spire -f values.yaml --set "spire-server.dataStore.sql.password=${DBPW}"
+helm upgrade --install --namespace spire-server spire charts/spire -f examples/external-postgresql/values.yaml --set "spire-server.dataStore.sql.password=${DBPW}"
 
 ```
 

--- a/examples/production/README.md
+++ b/examples/production/README.md
@@ -12,27 +12,27 @@ kubectl label namespace "spire-server" pod-security.kubernetes.io/enforce=restri
 Update the `example-your-values.yaml` file with your values, then:
 
 ```shell
-helm upgrade --install --namespace spire-server spire ../../charts/spire \
-  -f values.yaml -f example-your-values.yaml --render-subchart-notes
+helm upgrade --install --namespace spire-server spire charts/spire \
+  -f examples/production/values.yaml -f examples/production/example-your-values.yaml --render-subchart-notes
 ```
 
 If your using ingress-nginx and want to expose the spiffe oidc discovery provider outside the
 cluster, add the following to the end of the helm upgrade example:
 
 ```shell
--f values-expose-spiffe-oidc-discovery-provider-ingress-nginx.yaml
+-f examples/production/values-expose-spiffe-oidc-discovery-provider-ingress-nginx.yaml
 ```
 
 If you want to expose your spire-server outside of Kubernetes and are using ingress-nginx, add following values file when running `helm template/install/upgrade`.
 
 ```shell
--f values-expose-spire-server-ingress-nginx.yaml
+-f examples/production/values-expose-spire-server-ingress-nginx.yaml
 ```
 
 For example:
 
 ```shell
-helm upgrade --install --namespace spire-server spire charts/spire -f values.yaml -f values-expose-spire-server-ingress-nginx.yaml
+helm upgrade --install --namespace spire-server spire charts/spire -f examples/production/values.yaml -f examples/production/values-expose-spire-server-ingress-nginx.yaml
 ```
 
 If you want to expose your federation endpoint outside of Kubernetes and are using ingress-nginx
@@ -42,25 +42,25 @@ you have two options as described here:
 If you chose profile https_web, use:
 
 ```shell
--f values-expose-federation-https-web-ingress-nginx.yaml
+-f examples/production/values-expose-federation-https-web-ingress-nginx.yaml
 ```
 
 For example:
 
 ```shell
-helm upgrade --install --namespace spire-server spire charts/spire -f values.yaml -f values-expose-federation-https-web-ingress-nginx.yaml
+helm upgrade --install --namespace spire-server spire charts/spire -f examples/production/values.yaml -f examples/production/values-expose-federation-https-web-ingress-nginx.yaml
 ```
 
 If you chose profile https_spiffe, use:
 
 ```shell
--f values-expose-federation-https-spiffe-ingress-nginx.yaml
+-f examples/production/values-expose-federation-https-spiffe-ingress-nginx.yaml
 ```
 
 For example:
 
 ```shell
-helm upgrade --install --namespace spire-server spire charts/spire -f values.yaml -f values-expose-federation-https-spiffe-ingress-nginx.yaml
+helm upgrade --install --namespace spire-server spire charts/spire -f examples/production/values.yaml -f examples/production/values-expose-federation-https-spiffe-ingress-nginx.yaml
 ```
 
 See [values.yaml](./values.yaml) for more details on the chart configurations to achieve this setup.

--- a/examples/tornjak/README.md
+++ b/examples/tornjak/README.md
@@ -12,11 +12,11 @@ kubectl create namespace "spire-server"
 kubectl label namespace "spire-server" pod-security.kubernetes.io/enforce=restricted
 
 # deploy SPIRE with Tornjak enabled
-helm upgrade --install --namespace spire-server \
-  --values ../production/values.yaml \
-  --values ./values.yaml \
-  --render-subchart-notes \
-  spire ../../charts/spire
+helm upgrade --install --namespace spire-server spire charts/spire \
+--values examples/production/values.yaml \
+--values examples/tornjak/values.yaml \
+--render-subchart-notes
+
 
 # test the Tornjak deployment
 helm test spire -n spire-server


### PR DESCRIPTION
We need to decide which format we want to use across all the examples:

1. `helm upgrade --install --namespace spire-server spire charts/spire -f examples/production/values.yaml -f examples/openshift/values.yaml`

1. `helm upgrade --install --namespace spire-server spire ../../charts/spire -f values.yaml -f ../openshift/values.yaml`

Personally, I prefer the case 1. 