### PR TITLE
Introduce ReadOnlyRootFilesystem for Tornjak frontend

### DIFF
--- a/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
+++ b/charts/spire/charts/tornjak-frontend/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               mountPath: {{ .Values.workingDir }}/node_modules/.cache
             - name: env
               mountPath: {{ .Values.workingDir }}/build/tmp
+            - name: logs
+              mountPath: /opt/app-root/src/.npm/
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -76,4 +78,6 @@ spec:
         - name: cache
           emptyDir: {}
         - name: env
+          emptyDir: {}
+        - name: logs
           emptyDir: {}

--- a/examples/production/values.yaml
+++ b/examples/production/values.yaml
@@ -124,7 +124,7 @@ tornjak-frontend:
   securityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    readOnlyRootFilesystem: false
+    readOnlyRootFilesystem: true 
     capabilities:
       drop: [ALL]
     seccompProfile:


### PR DESCRIPTION
Eliminate the `ReadOnlyRootFilesystem=false` case of Tornjak