### PR TITLE
SELinux support

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/README.md
+++ b/charts/spire/charts/spiffe-csi-driver/README.md
@@ -64,3 +64,8 @@ A Helm chart to install the SPIFFE CSI driver.
 | `restrictedScc.enabled`                  | Enables the creation of a SecurityContextConstraint based on the restricted SCC with CSI volume support | `false`                                     |
 | `restrictedScc.name`                     | Set the name of the restricted SCC with CSI support                                                     | `""`                                        |
 | `restrictedScc.version`                  | Version of the restricted SCC                                                                           | `2`                                         |
+| `selinux.context`                        | Which selinux context to use                                                                            | `container_file_t`                          |
+| `selinux.image.registry`                 | The OCI registry to pull the image from                                                                 | `registry.access.redhat.com`                |
+| `selinux.image.repository`               | The repository within the registry                                                                      | `ubi9`                                      |
+| `selinux.image.pullPolicy`               | The image pull policy                                                                                   | `Always`                                    |
+| `selinux.image.tag`                      | Overrides the image tag whose default is the chart appVersion                                           | `latest`                                    |

--- a/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
@@ -36,9 +36,31 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- with .Values.initContainers }}
+      {{- if or (gt (len .Values.initContainers) 0) (dig "openshift" false .Values.global) (dig "selinux" false .Values.global)}}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+      {{- if or (dig "openshift" false .Values.global) (dig "selinux" false .Values.global) }}
+        - name: set-context
+          command:
+            - chcon
+            - '-Rvt'
+            - {{ .Values.selinux.context }}
+            - spire-agent-socket/
+          image: {{ template "spire-lib.image" (dict "appVersion" $.Chart.AppVersion "image" .Values.selinux.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.selinux.image.pullPolicy }}
+          securityContext:
+            capabilities:
+              drop:
+                - all
+            privileged: true
+          volumeMounts:
+            - name: spire-agent-socket-dir
+              mountPath: /spire-agent-socket
+          terminationMessagePolicy: File
+          terminationMessagePath: /dev/termination-log
+      {{- end }}
+      {{- if gt (len .Values.initContainers) 0 }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         # This is the container which runs the SPIFFE CSI driver.

--- a/charts/spire/charts/spiffe-csi-driver/values.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/values.yaml
@@ -141,3 +141,16 @@ restrictedScc:
   name: ""
   ## @param restrictedScc.version Version of the restricted SCC
   version: 2
+
+selinux:
+  ## @param selinux.context Which selinux context to use
+  context: container_file_t
+  ## @param selinux.image.registry The OCI registry to pull the image from
+  ## @param selinux.image.repository The repository within the registry
+  ## @param selinux.image.pullPolicy The image pull policy
+  ## @param selinux.image.tag Overrides the image tag whose default is the chart appVersion
+  image:
+    registry: registry.access.redhat.com
+    repository: ubi9
+    pullPolicy: Always
+    tag: latest

--- a/examples/openshift/openshift-values.yaml
+++ b/examples/openshift/openshift-values.yaml
@@ -50,24 +50,3 @@ tornjak-frontend:
     runAsUser: null
     runAsGroup: null
     fsGroup: null
-
-spiffe-csi-driver:
-  initContainers:
-    - terminationMessagePath: /dev/termination-log
-      name: set-context
-      command:
-        - chcon
-        - '-Rvt'
-        - container_file_t
-        - spire-agent-socket/
-      securityContext:
-        capabilities:
-          drop:
-            - all
-        privileged: true
-      imagePullPolicy: Always
-      volumeMounts:
-        - name: spire-agent-socket-dir
-          mountPath: /spire-agent-socket
-      terminationMessagePolicy: File
-      image: 'registry.access.redhat.com/ubi9:latest'


### PR DESCRIPTION
Add support to the chart to set the SELinux context to enable a working system. Enable it by default on OpenShift clusters.