### PR TITLE
Bump spire Helm Chart version from 0.15.1 to 0.16.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.15.1
+version: 0.16.0
 appVersion: "1.8.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
@@ -28,7 +28,7 @@ Then:
 helm install -n spire-server spire --repo https://spiffe.github.io/helm-charts-hardened/ -f your-values.yaml
 ```
 
-For production installs, please see [the production example](https://github.com/spiffe/helm-charts-hardened/tree/main/examples/production).
+For production installs, please see [the production example](https://github.com/spiffe/helm-charts-hardened/tree/spire-0.16.0/examples/production).
 
 ## Upgrade notes
 

--- a/release-chart.sh
+++ b/release-chart.sh
@@ -40,9 +40,9 @@ function print_error_and_exit {
 }
 
 function unreleased_changes_other_charts {
-  for chart in "${1[@]}" ; do
-    latest_tag="$(git tag --list "${chart}-[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)"
-    changes="$(git log "${latest_tag}..HEAD" --pretty=format:'* %h %s' "charts/${chart}")"
+  for chart in "$@" ; do
+    latest_tag="$(git --no-pager tag --list "${chart}-[0-9]*.[0-9]*.[0-9]*" | sort -V | tail -n 1)"
+    changes="$(git --no-pager log "${latest_tag}..HEAD" --pretty=format:'* %h %s' "charts/${chart}")"
     if [ -n "${changes}" ] ; then
       echo "### Unreleased changes ${chart}"
       echo
@@ -119,7 +119,7 @@ git checkout --track -B "${branch_name}" main
 current_version="$(grep '^version:' "charts/${chart}/Chart.yaml" | awk '{print $2}')"
 commits_since_previous_release="$(git log "${chart}-${current_version}..HEAD" --pretty=format:'* %h %s' "charts/${chart}")"
 "${SED}" -i "s/version: ${current_version}/version: ${new_version}/" "charts/${chart}/Chart.yaml"
-"${SED}" -i "s/${current_version}/${new_version}/" "charts/${chart}/README.md"
+"${SED}" -i "s/${current_version}/${new_version}/g" "charts/${chart}/README.md"
 git add "charts/${chart}/"{Chart.yaml,README.md}
 git commit -m "Bump ${chart} Helm Chart version from ${current_version} to ${new_version}" \
   -m "${commits_since_previous_release}" \


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.



> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* b7d8590 Fix missing protocol in JWT Issuer  (#120)
* 1ef207c Add note about supported version upgrades (#119)
* 4281114 Fix missing release name from install documentation (#118)
* e030fa1 Allow additional CRs to be managed by the chart (#117)
* d936293 Enable agent to kubelet connection to use hostname (#112)
* e68f617 Bump test chart dependencies (#116)
* d616632 Bump spire version to 1.8.5 (#115)
* 95e1eb7 Bump test chart dependencies
* 966061c Auto add default CSIDriver labels on OpenShift
* c9885de Introduce ReadOnlyRootFilesystem for Tornjak frontend (#110)
* 8107095 Fix typo ClusterSPIFFEID for workloadTSelectoremplates (#107)
* 5c0ce97 Ordering of SecurityContextConstraint array items (#105)
* 889d0af Bump test chart dependencies
* f5d1376 Documentation cleanup (#97)
