### PR TITLE
Update default for additionalDomains not to include localhost

### DIFF
--- a/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/values.yaml
@@ -132,8 +132,8 @@ config:
   ## @param config.logLevel The log level, valid values are "debug", "info", "warn", and "error"
   logLevel: info
   ## @param config.additionalDomains [array] Add additional domains that can be used for oidc discovery
-  additionalDomains:
-    - localhost
+  additionalDomains: []
+  # - localhost
 
   acme:
     ## @param config.acme.tosAccepted Flag for Terms of Service acceptance

--- a/examples/production/values.yaml
+++ b/examples/production/values.yaml
@@ -94,8 +94,6 @@ upstream-spire-agent:
 
 spiffe-oidc-discovery-provider:
   enabled: true
-  config:
-    additionalDomains: []
   insecureScheme:
     enabled: true
   podSecurityContext:


### PR DESCRIPTION
Its pretty much only useful if you want to port forward the discovery provider and use localhost to access it. An uncommon use case. Its easy to add back for that case. This simplifies production deployment.