### PR TITLE
Bump k8s versions for ci workflow

### DIFF
--- a/.github/workflows/helm-chart-ci-ignore.yaml
+++ b/.github/workflows/helm-chart-ci-ignore.yaml
@@ -30,9 +30,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.27.2
-          - v1.26.4
-          - v1.25.9
+          - v1.29.0
+          - v1.28.0
+          - v1.27.3
+          - v1.26.6
 
     steps:
       - run: 'echo "Skipping tests"'
@@ -65,9 +66,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.27.2
-          - v1.26.4
-          - v1.25.9
+          - v1.29.0
+          - v1.28.0
+          - v1.27.3
+          - v1.26.6
         example:
           - ${{ fromJson(needs.build-matrix.outputs.examples) }}
 

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -130,9 +130,10 @@ jobs:
         # Kubernetes, but can go back farther as long as we don't need heroics
         # to pull it off (i.e. kubectl version juggling).
         k8s:
-          - v1.27.2
-          - v1.26.4
-          - v1.25.9
+          - v1.29.0
+          - v1.28.0
+          - v1.27.3
+          - v1.26.6
 
     steps:
       - name: Checkout
@@ -209,9 +210,10 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.27.2
-          - v1.26.4
-          - v1.25.9
+          - v1.29.0
+          - v1.28.0
+          - v1.27.3
+          - v1.26.6
         example:
           - ${{ fromJson(needs.build-matrix.outputs.examples) }}
 
@@ -255,9 +257,10 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.27.2
-          - v1.26.4
-          - v1.25.9
+          - v1.29.0
+          - v1.28.0
+          - v1.27.3
+          - v1.26.6
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Following the versions as defined at https://kubernetes.io/releases/

> [!Note]
> Kind does not offer the latest patch releases for each minor, therefore
running on the latest patch releases offered by kind.
> ```shell
> $ crane ls kindest/node
> …
> …
> v1.26.0
> v1.26.2
> v1.26.3
> v1.26.4
> v1.26.6
> v1.27.0
> v1.27.1
> v1.27.2
> v1.27.3
> v1.28.0
> v1.29.0
> ```

> [!Warning]
> Prior to merging this PR we have to update the branch protection
settings regarding required jobs.