### PR TITLE
Remove 1.29.0 until deps catch up.

### DIFF
--- a/.github/workflows/helm-chart-ci-ignore.yaml
+++ b/.github/workflows/helm-chart-ci-ignore.yaml
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29.0
           - v1.28.0
           - v1.27.3
           - v1.26.6
@@ -66,7 +65,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29.0
           - v1.28.0
           - v1.27.3
           - v1.26.6

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -130,7 +130,6 @@ jobs:
         # Kubernetes, but can go back farther as long as we don't need heroics
         # to pull it off (i.e. kubectl version juggling).
         k8s:
-          - v1.29.0
           - v1.28.0
           - v1.27.3
           - v1.26.6
@@ -210,7 +209,6 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.29.0
           - v1.28.0
           - v1.27.3
           - v1.26.6
@@ -257,7 +255,6 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.29.0
           - v1.28.0
           - v1.27.3
           - v1.26.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 >  **Note**
 > Things to consider:
 > 1. We do not support running out of the git main branch. This is where development happens. Please use released versions via the published repo or git tags.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 >  **Note**
 > Things to consider:
 > 1. We do not support running out of the git main branch. This is where development happens. Please use released versions via the published repo or git tags.


### PR DESCRIPTION
Related issue: https://github.com/rancher/kubectl/pull/94

> [!Warning]
> Prior to merging this PR we have to update the branch protection
settings regarding required jobs.