### PR TITLE
Fix agent daemonset format

### DIFF
--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -72,8 +72,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["-config", "/run/spire/config/agent.conf"]
           env:
-          - name: PATH
-            value: "/opt/spire/bin:/bin"
+            - name: PATH
+              value: "/opt/spire/bin:/bin"
           {{- if $cbh }}
             - name: MY_NODE_NAME
               valueFrom:


### PR DESCRIPTION
Very minor formatting bug, that causes formatting errors when OpenShift enabled. 