### PR TITLE
Bump spire Helm Chart version from 0.16.0 to 0.17.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: "1.8.7"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.


> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 4c307c1 Add missing bundlePublisher section and extraEnv so settings can be set (#201)
* d724d1e Update the documentation (#172)
* e59a29b Bump test chart dependencies (#200)
* 4668151 Add missing extraVolumeMounts to the controllerManager (#196)
* b9ac3c4 Update to spire-controller-manager 0.4.1 (#193)
* 6fec1e5 Update SPIRE to 1.8.7 (#194)
* af155c2 Add support for running spiffe secured discovery provider (default) (#163)
* 3ccdb5e Add tls section to federation bundle endpoint and fix up annotations (#173)
* c7ab131 Add join_token server nodeattestor support (#187)
* 81e9523 Bump test chart dependencies (#186)
* 6d19a76 Fix agent daemonset format (#184)
* b61d4f5 Add spire-agent to spire-agent pod path (#180)
* befa074 Fix notes bug (#178)
* 912c61e Remove deprecated version values (#179)
* ae4ef6e Update HorizontalPodAutoscaler API to autoscaling/v2 (#153)
* e7a61a9 Bump test chart dependencies
* 183e9aa SPIFFE OIDC Discovery Provider Rework (#152)
* 8f1aba8 Bump test chart dependencies (#171)
* 2454b8c Fix links still pointing at older git repo (#167)
* e5c5527 Bump test chart dependencies (#165)
* e630008 Update jwt test to work with newer slim images (#139)
* c39dd44 Add recommendation for namespacePSS (#131)
* 49beb64 Add recommendation for namespaceLayout (#127)
* 33cacd2 Add recommendation for prometheus exporter (#144)
* 6997d6a Add recommendation for securityContext and podSecurityContext (#125)
* 50c4ac3 Add recommendation for strictMode (#143)
* 4fb9d18 Bump test chart dependencies (#155)
* 811123a Update the Tornjak image version (#150)
* 1524537 Update default for additionalDomains not to include localhost (#146)
* e35838c Add recommendation for priorityClass (#124)
* 9f72a8f Use good and automatic defaults for tornjak frontend workingDir (#129)
* 7726351 Tornjak UBI support (#123)
* 89c07e2 Revert openssl 3.2 change (#142)
* a3d3702 Bump test chart dependencies
* 80c7653 Bump test chart dependencies (#134)
* 13f6028 SELinux support (#122)
* 3e8335c Add a flag to enable recommendations (#121)
* 692d463 Remove unneeded lookup function from upgrade hook (#104)
* 8422b8d Added ability to create namespaces (#103)
