### PR TITLE
Update spire-agent daemonset with pod annotation for default container

### DIFF
--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: spire-agent
         checksum/config: {{ $configSum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Doubt there is a need to provide this as an option.