### PR TITLE
Update spire-server with default container annotation.

### DIFF
--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -29,6 +29,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: spire-server
         checksum/config: {{ $configSum }}
         checksum/config2: {{ $configSum2 }}
         checksum/config3: {{ $configSum3 }}


### PR DESCRIPTION
Adding default container annotation to the stateful set