### PR TITLE
Always upgrade test from the previous major release

### DIFF
--- a/examples/production/run-tests.sh
+++ b/examples/production/run-tests.sh
@@ -26,7 +26,7 @@ for i in "$@"; do
     -u)
       if [[ -z "$UPGRADE_VERSION" ]]; then
         echo "Failed to detect previous version."
-	exit 1
+        exit 1
       fi
       UPGRADE_ARGS="--repo $UPGRADE_REPO --version $UPGRADE_VERSION"
       shift # past argument=value

--- a/examples/production/run-tests.sh
+++ b/examples/production/run-tests.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-UPGRADE_VERSION=v0.15.1
+UPGRADE_VERSION=$(git tag -l 'spire-0.*' | awk -F. '{print $2}' | sort -n | tail -n 1 | sed 's/^/v0./; s/$/.0/')
 UPGRADE_REPO=https://spiffe.github.io/helm-charts-hardened
 
 SCRIPT="$(readlink -f "$0")"

--- a/examples/production/run-tests.sh
+++ b/examples/production/run-tests.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-UPGRADE_VERSION=$(git tag -l 'spire-0.*' | awk -F. '{print $2}' | sort -n | tail -n 1 | sed 's/^/v0./; s/$/.0/')
+UPGRADE_VERSION=$(git ls-remote --tags origin -l 'spire-0.*' | awk -F. '{print $2}' | sort -n | tail -n 1 | sed 's/^/v0./; s/$/.0/')
 UPGRADE_REPO=https://spiffe.github.io/helm-charts-hardened
 
 SCRIPT="$(readlink -f "$0")"

--- a/examples/production/run-tests.sh
+++ b/examples/production/run-tests.sh
@@ -24,6 +24,10 @@ CLEANUP=1
 for i in "$@"; do
   case $i in
     -u)
+      if [[ -z "$UPGRADE_VERSION" ]]; then
+        echo "Failed to detect previous version."
+	exit 1
+      fi
       UPGRADE_ARGS="--repo $UPGRADE_REPO --version $UPGRADE_VERSION"
       shift # past argument=value
       ;;


### PR DESCRIPTION
Previously the upgrade test had a hard coded version to try to upgrade from. This PR updates it so that it automatically detects the newest major release version in the series but uses the start of the series. So for example, test upgrading from 0.17.0 rather then upgrading from 0.17.1.