### PR TITLE
Remove the white line from securityContext rendering

### DIFF
--- a/charts/spire/templates/_spire-lib.tpl
+++ b/charts/spire/templates/_spire-lib.tpl
@@ -273,7 +273,7 @@ fsGroupChangePolicy: OnRootMismatch
 {{- end }}
 
 {{- define "spire-lib.securitycontext" }}
-{{ include "spire-lib.securitycontext-extended" (dict "root" . "securityContext" .Values.securityContext) }}
+{{- include "spire-lib.securitycontext-extended" (dict "root" . "securityContext" .Values.securityContext) }}
 {{- end }}
 
 {{/* Same as securitycontext but takes in:


### PR DESCRIPTION
Prevents the following diff introduced since the 0.17.0 release.

```diff
        containers:
        - name: post-install-job
          securityContext:
+
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault
```
