### PR TITLE
Fix to apply securityContext recommendation to spire-agent init container

### DIFF
--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
           securityContext:
-            {{ toYaml .Values.securityContext | nindent 12 }}
+            {{- include "spire-lib.securitycontext" . | nindent 12 }}
         {{- if gt (int (dig "fsGroup" 0 $podSecurityContext)) 0 }}
         - name: fsgroupfix
           image: {{ template "spire-lib.image" (dict "image" .Values.fsGroupFix.image "global" .Values.global) }}


### PR DESCRIPTION
Attempt to add the securityContext back to this init container. However the macro function doesn't cater for being able to override the securityContext at spire-agent.waitForIt.securityContext.

@kfox1111 any thoughts on what would be required to fix this usecase for spire-agent init containers and probably others that we have missed, so the recommendation applies it on all container as opposed to just a selection?
