### PR TITLE
Fix OpenShift Federation Ingress bug

### DIFF
--- a/charts/spire/charts/spire-server/templates/federation-ingress.yaml
+++ b/charts/spire/charts/spire-server/templates/federation-ingress.yaml
@@ -14,7 +14,6 @@
 {{-   $_ := set $federationIngress "tlsSecret" .Values.federation.tls.externalSecret.secretName }}
 {{- end }}
 {{- $ingressControllerType := include "spire-lib.ingress-controller-type" (dict "global" .Values.global "ingress" .Values.federation.ingress) }}
-{{- $tlsSection := true }}
 {{- $annotations := deepCopy .Values.federation.ingress.annotations }}
 {{- if eq $ingressControllerType "ingress-nginx" }}
 {{-   $_ := set $annotations "nginx.ingress.kubernetes.io/ssl-redirect" "true" }}

--- a/charts/spire/charts/spire-server/templates/federation-ingress.yaml
+++ b/charts/spire/charts/spire-server/templates/federation-ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.federation.enabled }}
 {{- if .Values.federation.ingress.enabled -}}
 {{- $svcName := include "spire-server.fullname" . }}
+{{- $path := "/"}}
+{{- $pathType := "Prefix" }}
+{{- $tlsSection := true }}
 {{/* Until https://github.com/spiffe/spire/issues/2202 is resolved, use ingress to implement cert-manager and externalSecret support. */}}
 {{- $federationIngress := deepCopy .Values.federation.ingress }}
 {{- if .Values.federation.tls.certManager.enabled }}
@@ -42,6 +45,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ include "spire-lib.ingress-spec" (dict "ingress" $federationIngress "svcName" $svcName "port" .Values.federation.bundleEndpoint.port "path" "/" "pathType" "Prefix" "tlsSection" $tlsSection "Values" .Values) | nindent 2 }}
+  {{ include "spire-lib.ingress-spec" (dict "ingress" $federationIngress "svcName" $svcName "port" .Values.federation.bundleEndpoint.port "path" $path "pathType" $pathType "tlsSection" $tlsSection "Values" .Values) | nindent 2 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Working on demoing SPIRE Federation on OpenShift - Helm chart currently fails on deployment with following helm values on Openshift:

```
spire-server:
  ingress:
    enabled: true
  federation:
    enabled: true
    ingress:
      enabled: true
```

With error:

```
Error: template: spire/charts/spire-server/templates/federation-ingress.yaml:28:14: executing "spire/charts/spire-server/templates/federation-ingress.yaml" at <"">: undefined variable: $path
```