### PR TITLE
Fix issue with tests not running  on automated PRs

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -60,7 +60,7 @@ jobs:
           git diff
 
       - name: Generate Token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@v2.1.0
         id: generate-token
         with:
           app_id: ${{ vars.APP_ID }}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -59,11 +59,18 @@ jobs:
           ./.github/scripts/update-tags.sh
           git diff
 
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v6.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Bump test chart dependencies
           branch: bump-test-chart-deps
           commit-message: Bump test chart dependencies


### PR DESCRIPTION
Use a github app to generate token for the version checker to use when creating PRs. Draft until SSC adds the github app to this repo. Currently using a github app in personal account. Will request official app in spire org after validating this works ok.

fixes #10 