### PR TITLE
Bump spire Helm Chart version from 0.17.2 to 0.18.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.17.2
+version: 0.18.0
 appVersion: "1.9.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.17.2](https://img.shields.io/badge/Version-0.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.



> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* beda725 Add pod labels to the SPIRE agent (#273)
* 077f152 Bump test chart dependencies (#272)
* 5849ea2 add pod labels to spire server values (#271)
* f512b06 Configurable daemonsets updateStrategy (#212)
* a539065 Add direct tpm support for spire-agent (#216)
* fcd0c11 Add direct tpm support for spire-server (#211)
* c570174 Enable CA settings via global (#268)
* ac83694 Initial SPIRE 1.9.0 support (#262)
* ddb4eff Bump test chart dependencies (#263)
* bfbafbc Fix OpenShift Federation Ingress bug (#260)
* a0baace Upgrade to spire-controller-manager 0.4.3 (#258)
* 1446f7e Add support for specifying agent authorized_delegates (#255)
* 0b6cd88 Add support for specifying server admin_ids (#254)
* 07a1c39 Add global override for kubectl tag (#251)
* b82a84d Bump test chart dependencies (#252)
* 7a1e731 Bump test chart dependencies (#246)
* a706063 make audit_log_enabled configurable (#241)
* 34a39cb Added emptyDir volume to spire-agent SCC (#243)
* a2e5a4e Add support for enabling the spire-agent admin socket (#234)
* febdcbf Fix whitespace in spire-agent daemonset
