### PR TITLE
Fix duplicate securityContext section in spire-agent

### DIFF
--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -108,8 +108,6 @@ spec:
           image: {{ template "spire-lib.image" (dict "image" .Values.waitForIt.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.waitForIt.image.pullPolicy }}
           args: ["-t", "30", "-h", "{{ include "spire-agent.server-address" . | trim }}", "-p", {{ .Values.server.port | quote }}]
-          securityContext:
-            {{- .Values.securityContext | toYaml | nindent 12 }}
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
A duplicate section was added due to incorrect merge conflict resolution. Helm seems ok with it but Kustomize + FluxCD has issues with it.