### PR TITLE
Bump spire-crds Helm Chart version from 0.3.0 to 0.4.0

### DIFF
--- a/charts/spire-crds/Chart.yaml
+++ b/charts/spire-crds/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-crds
 description: >
   A Helm chart for deploying the Spire CRDS
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.0.1"
 keywords: ["spire-crds"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire

* 1bf3aa7 Default spire-server port 443 (#308)
* 1ef979c Remove upgrade hook needed in 0.19.x (#317)
* aa92791 Upgrade to spire-controller-manager 0.5.0 (#316)
* c1e4feb Fix ingress host with a dot (#323)
* 5b1bf43 Update spire to 1.9.4 (#324)
* dcd11e9 Fix chainguard issue (#326)
* bc79f58 AWS KMS key_identifier upgrade (#314)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* aa92791 Upgrade to spire-controller-manager 0.5.0 (#316)
