### PR TITLE
Don't create role/binding when bundle disabled

### DIFF
--- a/charts/spire/charts/spire-server/templates/roles.yaml
+++ b/charts/spire/charts/spire-server/templates/roles.yaml
@@ -1,6 +1,7 @@
 {{- $subject := include "spire-server.subject" . }}
 {{- $namespace := include "spire-server.namespace" . }}
 {{- $bundleNamespace := include "spire-server.bundle-namespace" . }}
+{{- if .Values.notifier.k8sbundle.enabled }}
 # Role to be able to push certificate bundles to a configmap
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +15,7 @@ rules:
     verbs:
       - get
       - patch
+{{- end }}
 {{- if and .Values.upstreamAuthority.certManager.enabled .Values.upstreamAuthority.certManager.rbac.create }}
 ---
 # Role to be able to manage cert requests with Cert-Manager
@@ -46,6 +48,7 @@ roleRef:
   name: {{ include "spire-server.fullname" . }}-cm
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- if .Values.notifier.k8sbundle.enabled }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,7 +60,7 @@ roleRef:
   kind: Role
   name: {{ include "spire-lib.bundle-configmap" . }}
   apiGroup: rbac.authorization.k8s.io
-
+{{- end }}
 {{- if and .Values.nodeAttestor.k8sPsat.enabled }}
 ---
 # ClusterRole to allow spire-server node attestor to query Token Review API


### PR DESCRIPTION
When the bundle notifier is disabled, there is no need to create a role and role binding for it.