### PR TITLE
Fix federation certificate name when upstream enabled

### DIFF
--- a/charts/spire/charts/spire-server/templates/federation-certificate.yaml
+++ b/charts/spire/charts/spire-server/templates/federation-certificate.yaml
@@ -20,7 +20,7 @@ secretName: {{ $issuerFullName }}-cert
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "spire-server.fullname" . }}
+  name: {{ include "spire-server.fullname" . }}-fed
   namespace: {{ include "spire-server.namespace" . }}
 spec:
   {{ merge (include "spire-server.federation-cert-manager-default-cert" . | fromYaml) .Values.federation.tls.certManager.certificate | toYaml | nindent 2 }}


### PR DESCRIPTION
When both federation certificates and upstream authority both use cert-manager, there is a naming conflict.