### PR TITLE
Fix upstream ca name suffix issue

### DIFF
--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -75,6 +75,11 @@ kubectl delete crds clusterfederatedtrustdomains.spire.spiffe.io clusterspiffeid
 
 We only support upgrading one major version at a time. Version skipping isn't supported.
 
+### 0.21.X
+
+- In previous versions, spire-server.upstreamAuthority.certManager.issuer_name would incorrectly have '-ca' appended. Starting with this version, that is no longer the case. If you previously set this
+value, you likely want to update your value to include the '-ca' suffix in the value to have your deployment continue to function properly.
+
 ### 0.20.X
 
 - The default service port for the spire-server was changed to be port 443 to allow easier switching between internal access and external access through an ingress controller. For most users, this will be a transparent

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -269,7 +269,7 @@ plugins:
   UpstreamAuthority:
     cert-manager:
       plugin_data:
-        issuer_name: {{ default (printf "%s-ca (include "spire-server.fullname" $root)) .issuer_name }}
+        issuer_name: {{ default (printf "%s-ca" (include "spire-server.fullname" $root)) .issuer_name }}
         issuer_kind: {{ .issuer_kind | quote }}
         issuer_group: {{ .issuer_group | quote }}
         namespace: {{ default $root.Release.Namespace .namespace | quote }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -269,7 +269,7 @@ plugins:
   UpstreamAuthority:
     cert-manager:
       plugin_data:
-        issuer_name: {{ default (include "spire-server.fullname" $root) .issuer_name }}-ca
+        issuer_name: {{ default (printf "%s-ca (include "spire-server.fullname" $root)) .issuer_name }}
         issuer_kind: {{ .issuer_kind | quote }}
         issuer_group: {{ .issuer_group | quote }}
         namespace: {{ default $root.Release.Namespace .namespace | quote }}


### PR DESCRIPTION
The cert-manager upstream authority incorrectly suffixes '-ca' onto the name when specified.

Partially fixes: https://github.com/spiffe/helm-charts-hardened/issues/358