### PR TITLE
Bump spire Helm Chart version from 0.20.0 to 0.21.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.20.0
+version: 0.21.0
 appVersion: "1.9.6"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.6](https://img.shields.io/badge/AppVersion-1.9.6-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.6](https://img.shields.io/badge/AppVersion-1.9.6-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.



> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 54a2f03 Change cleanup default (#349)
* d29ad06 Bump test chart dependencies (#369)
* 7dabbf1 Add Openshift ignore namespaces to Controller Manager (#363)
* db177d4 Fix spelling error in Controller Manager config (#362)
* d236154 Fix upstream ca name suffix issue (#361)
* bfcf418 Bump test chart dependencies (#359)
* c31a2e9 Bump up spire to 1.9.6 (#356)
* 2c5dfa0 Improve Tornjak NOTES. Fixes #132 (#354)
* a453a2c Bump test chart dependencies (#355)
* b6575c1 Update Tornjak deployment docs (#288)
* be560d9 Check for a misconfiguration of bundle endpoint profiles (#348)
* b2e9f40 Bump spire version (#352)
* 7165b20 Bump test chart dependencies (#350)
* da4ebdf Fix federation certificate name when upstream enabled (#347)
* c37de1e Fix Tornjak logsDir for Openshift (#344)
* 8fef1bd Add external spire-controller-managers (#284)
* ee12404 set refresh hint to 1/3 of default CA TTL value fixes #335 (#343)
* 2d9866a Bump test chart dependencies (#338)
* 6de23d3 Don't create role/binding when bundle disabled (#336)
* c132cc4 Add support for externalServer=true (#303)
* a2494ee Add auth option for Tornjak (#259)
* f679a0d Bump test chart dependencies (#333)
* 5149256 Work around curl change
* 3d2ac16 Bump test chart dependencies
* 08f699b Add spire-lib chart (#289)
* 260b02f Add an easy to use identity for child servers (#302)
