### PR TITLE
Update keycloak-config-cli using SPIRE example to Keycloak >= 24.0.0

### DIFF
--- a/examples/keycloak-config-cli-using-spire/README.md
+++ b/examples/keycloak-config-cli-using-spire/README.md
@@ -1,5 +1,10 @@
 # keycloak-config-cli using spire
 
+> [!WARNING]
+> This example uses
+> the [`SidecarContainers`](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#enabling-sidecar-containers)
+> feature. This is only enabled by default in Kubernetes 1.29+.
+
 This example shows how to leverage SPIRE in establishing an mTLS connection
 between [Keycloak (>= 24.0.0)](https://www.keycloak.org/) and [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli),
 a tool to configure Keycloak.
@@ -9,7 +14,7 @@ a tool to configure Keycloak.
 1. Create a local cluster for testing
 
 ```shell
-kind create cluster
+kind create cluster --image kindest/node:v1.29.0
 ```
 
 2. Install CRDs

--- a/examples/keycloak-config-cli-using-spire/README.md
+++ b/examples/keycloak-config-cli-using-spire/README.md
@@ -1,12 +1,7 @@
 # keycloak-config-cli using spire
 
-> [!WARNING]
-> This example uses
-> the [`SidecarContainers`](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#enabling-sidecar-containers)
-> feature. This is only enabled by default in Kubernetes 1.29+.
-
 This example shows how to leverage SPIRE in establishing an mTLS connection
-between [Keycloak](https://www.keycloak.org/) and [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli),
+between [Keycloak (>= 24.0.0)](https://www.keycloak.org/) and [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli),
 a tool to configure Keycloak.
 
 ## Setup
@@ -14,7 +9,7 @@ a tool to configure Keycloak.
 1. Create a local cluster for testing
 
 ```shell
-kind create cluster --image kindest/node:v1.29.0
+kind create cluster
 ```
 
 2. Install CRDs
@@ -32,7 +27,7 @@ helm upgrade --install -n spire-server spire ../../charts/spire --create-namespa
 4. Install `keycloak` (this also configures Keycloak for client certificate authentication)
 
 ```shell
-helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak -f keycloak-values.yaml
+helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak -f keycloak-values.yaml --version 21.4.4
 ```
 
 5. Install `keycloak-config-cli`

--- a/examples/keycloak-config-cli-using-spire/keycloak-config-cli.yaml
+++ b/examples/keycloak-config-cli-using-spire/keycloak-config-cli.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: keycloak-config-cli
 spec:
-  backoffLimit: 1
+  backoffLimit: 10
   template:
     metadata:
       labels:

--- a/examples/keycloak-config-cli-using-spire/keycloak-values.yaml
+++ b/examples/keycloak-config-cli-using-spire/keycloak-values.yaml
@@ -1,69 +1,62 @@
-extraDeploy:
-  - apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: java-spiffe-helper-properties
-    data:
-      java-spiffe-helper.properties: |
-        keyStorePath=/certs/keystore.p12
-        keyStorePass=password
-        keyPass=password
-        trustStorePath=/certs/truststore.p12
-        trustStorePass=password
-        keyStoreType=pkcs12
-        keyAlias=spiffe
-        spiffeSocketPath=unix:/run/spire/agent-sockets/spire-agent.sock
 service:
   extraPorts:
     - name: https
       port: 8443
       targetPort: 8443
 extraEnvVars:
-  - name: KC_HTTPS_CLIENT_AUTH
-    value: "request"
-  - name: KC_HTTPS_KEY_STORE_FILE
-    value: "/certs/keystore.p12"
-  - name: KC_HTTPS_KEY_STORE_PASSWORD
-    value: "password"
-  - name: KC_HTTPS_KEY_STORE_TYPE
-    value: "pkcs12"
-  - name: KC_HTTPS_TRUST_STORE_FILE
-    value: "/certs/truststore.p12"
-  - name: KC_HTTPS_TRUST_STORE_PASSWORD
-    value: "password"
-  - name: KC_HTTPS_TRUST_STORE_TYPE
-    value: "pkcs12"
+  - name: KC_HTTPS_CERTIFICATE_FILE
+    value: "/spire-certificates/svid.0.pem"
+  - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+    value: "/spire-certificates/svid.0.key"
 initContainers:
-  - name: java-spiffe-helper
-    image: ghcr.io/spiffe/java-spiffe-helper:0.8.5
-    imagePullPolicy: IfNotPresent
-    restartPolicy: Always
-    readinessProbe:
-      exec:
-        command:
-          - ls
-          - /certs/truststore.p12
+  - name: spire-agent-cli
+    image: ghcr.io/spiffe/spire-agent:1.9.6
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+    command:
+      - /opt/spire/bin/spire-agent
+    args:
+      - api
+      - fetch
+      - x509
+      - -socketPath=/run/spire/agent-sockets/spire-agent.sock
+      - -write=/spire-certificates
     volumeMounts:
-      - name: java-spiffe-helper-properties
-        mountPath: /app/java-spiffe-helper.properties
-        subPath: java-spiffe-helper.properties
+      - name: spire-certificates
+        mountPath: /spire-certificates
       - name: spire-sockets
         mountPath: /run/spire/agent-sockets
         readOnly: true
-      - name: certs
-        mountPath: /certs
+  - name: move
+    image: busybox:1.36
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+    args:
+      - mv
+      - /spire-certificates/bundle.0.pem
+      - /opt/bitnami/keycloak/conf/truststores/keycloak-config-cli/
+    volumeMounts:
+      - name: spire-certificates
+        mountPath: /spire-certificates
+      - name: truststores
+        mountPath: /opt/bitnami/keycloak/conf/truststores/keycloak-config-cli
 extraVolumeMounts:
-  - name: certs
-    mountPath: /certs
+  - name: spire-certificates
+    mountPath: /spire-certificates
+    readOnly: true
+  - name: truststores
+    mountPath: /opt/bitnami/keycloak/conf/truststores/keycloak-config-cli
+    readOnly: true
 extraVolumes:
-  - name: java-spiffe-helper-properties
-    configMap:
-      name: java-spiffe-helper-properties
   - name: spire-sockets
     hostPath:
       path: /run/spire/agent-sockets
       type: DirectoryOrCreate
-  - name: certs
+  - name: spire-certificates
+    emptyDir: {}
+  - name: truststores
     emptyDir: {}
 auth:
   adminPassword: "password"

--- a/examples/keycloak-config-cli-using-spire/keycloak-values.yaml
+++ b/examples/keycloak-config-cli-using-spire/keycloak-values.yaml
@@ -4,6 +4,8 @@ service:
       port: 8443
       targetPort: 8443
 extraEnvVars:
+  - name: KC_HTTPS_CLIENT_AUTH
+    value: "request"
   - name: KC_HTTPS_CERTIFICATE_FILE
     value: "/spire-certificates/svid.0.pem"
   - name: KC_HTTPS_CERTIFICATE_KEY_FILE


### PR DESCRIPTION
Keycloak >= 24.0.0 deprecated the use of password-protected truststores. This makes the integration with SPIRE quite a bit easier. This PR should update the example to reflect the changes.