### PR TITLE
Add connect by hostname to agent configmap

### DIFF
--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -116,6 +116,9 @@ plugins:
         disable_container_selectors: {{ .Values.workloadAttestors.k8s.disableContainerSelectors }}
         use_new_container_locator: {{ .Values.workloadAttestors.k8s.useNewContainerLocator }}
         verbose_container_locator_logs: {{ .Values.workloadAttestors.k8s.verboseContainerLocatorLogs }}
+        {{- if eq (include "spire-agent.connect-by-hostname" .) "true" }}
+        node_name_env: "MY_NODE_NAME"
+        {{- end }}
   {{- end }}
 
   {{- if .Values.workloadAttestors.unix.enabled }}


### PR DESCRIPTION
When setting the kubeletConnectByHostname to "true", the charts update the agent daemonset to define the MY_NODE_NAME environment variable, but it doesn't set the "node_name_env" setting in the WorkloadAttestor:k8s plugin, therefore the agent continues trying to connect to the kubelet using the localhost interface