### PR TITLE
Should be `admin_socket_path` not `admin_socket_dir`

### DIFF
--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -26,7 +26,7 @@
 {{- define "spire-agent.yaml-config" -}}
 agent:
   {{- if .Values.sockets.admin.enabled }}
-  admin_socket_dir: /tmp/spire-agent/private/admin.sock
+  admin_socket_path: /tmp/spire-agent/private/admin.sock
   {{- end }}
   {{- with .Values.authorizedDelegates }}
   authorized_delegates:


### PR DESCRIPTION
AFAICT this is just wrong and should be `admin_socket_path` - the `SPIRE` agent only has references to the latter, and using `dir` results in SPIRE agent config validation errors.