### PR TITLE
Bump spire Helm Chart version from 0.21.0 to 0.21.1

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.21.0
+version: 0.21.1
 appVersion: "1.10.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-nested

* c3d1d39 Update to SPIRE 1.10.0 (#393)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 82a6d5d Should be `admin_socket_path` not `admin_socket_dir` (#407)
* 6240c0b Bump test chart dependencies (#402)
* c3d1d39 Update to SPIRE 1.10.0 (#393)
* 741cd9c Bump test chart dependencies (#398)
* c507ee0 Bump test chart dependencies (#397)
* 199bb6f Add connect by hostname to agent cofigmap (#392)
* eb6d89b Update charts/spire/README.md
* c93ad87 Add valid kubectl version to examples
* 500fdd9 Bump test chart dependencies (#391)
* 08fc5f3 Bump test chart dependencies (#390)
* 6904295 Bump test chart dependencies (#389)
* fb7fb80 Fix format for ignoreNamespaces (#388)
* 7a0a77b Fix host path of "spire-agent-admin-socket-dir" volume (#386)
* 1d2d755 Add resource limits for upgrade and delete hook batch jobs (#366)
* f7e0d4b Update _spire-system-namespace.yaml (#381)
* 29d4b57 Bump test chart dependencies
* 4c9059e Bump test chart dependencies (#379)
* 1dc650f Apply wildcard for ignoreNamespaces in Controller Manager (#378)
* 6c2b5e6 Bump test chart dependencies (#376)
