### PR TITLE
Add missing properties required by SecurityContextConstraints CRD

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/templates/scc-spiffe-csi-driver.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/scc-spiffe-csi-driver.yaml
@@ -16,6 +16,7 @@ volumes:
   - configmap
   - hostPath
   - secret
+allowedCapabilities: null
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false
@@ -23,8 +24,11 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
+defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
 groups: []
+priority: null
+requiredDropCapabilities: null
 
 {{ end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/scc-spire-oidc-discovery-provider.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/scc-spire-oidc-discovery-provider.yaml
@@ -22,6 +22,7 @@ volumes:
   - hostPath
   - projected
   - secret
+allowedCapabilities: null
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true
@@ -29,9 +30,12 @@ allowHostPID: true
 allowHostPorts: true
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
+defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
 groups: []
+priority: null
+requiredDropCapabilities: null
 seccompProfiles:
   - '*'
 

--- a/charts/spire/charts/spire-agent/templates/scc-spire-agent.yaml
+++ b/charts/spire/charts/spire-agent/templates/scc-spire-agent.yaml
@@ -18,6 +18,7 @@ volumes:
   - projected
   - secret
   - emptyDir
+allowedCapabilities: null
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true
@@ -25,8 +26,11 @@ allowHostPID: true
 allowHostPorts: true
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
+defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
 groups: []
+priority: null
+requiredDropCapabilities: null
 
 {{ end }}


### PR DESCRIPTION
We add some OpenShift proprietary resource CRDs to more standard Kubernetes clusters like k3s/kind for feature branch testing. Our target clusters are OpenShift, so we want to enable the `global.openshift = true` in the Helm chart. This currently fails because some of the SCCs in the chart does not set some properties required by the SCC CRD: https://github.com/openshift/api/blob/2c10e58877296b062ee6fc63e7fda1eafe7d1bdc/payload-manifests/crds/0000_03_config-operator_01_securitycontextconstraints.crd.yaml#L351

There is something funky here, since the SCCs templated by the chart IS accepted by OpenShift - even if the SCC is missing these mandatory fields. But this appears to be an OpenShift issue, and not something I will try to fix....