### PR TITLE
Set readOnlyRootFilesystem to false in spire-agent SCC to avoid CLBO

### DIFF
--- a/charts/spire/charts/spire-agent/templates/scc-spire-agent.yaml
+++ b/charts/spire/charts/spire-agent/templates/scc-spire-agent.yaml
@@ -3,7 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ include "spire-agent.fullname" . }}
-readOnlyRootFilesystem: true
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
We couldn't get spire-agent running after switching to `openshift: true`. The spire-agent was reporting these errors and got stuck in CrashLoopBackOff.

```
time="2024-09-06T08:32:01Z" level=info msg="Creating spire agent UDS directory" dir=/run/spire/agent-sockets
mkdir /run/spire/agent-sockets: read-only file system
```

After changing the `readOnlyRootFilesystem` to `false` in the spire-agent SCC the spire-agent was able to start up.