### PR TITLE
Bump spire-nested Helm Chart version from 0.23.0 to 0.24.0

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.23.0
+version: 0.24.0
 appVersion: "1.11.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-crds

* 13736cd Add support for the new hint spire-controller-manager feature (#472)
* 01c7227 Add support for the new fallback spire-controller-manager feature (#471)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-crds --new-version ………
```
### Unreleased changes spire

* a3e607e Bump test chart dependencies (#484)
* a360646 Add validating admission policy to restrict upstream driver access (#482)
* a7368ee Upgrade to spire 1.11.0 (#483)
* fe5464b Update notes (#479)
* 29e9866 Bump test chart dependencies (#481)
* 13736cd Add support for the new hint spire-controller-manager feature (#472)
* b08e8bf Agent support for bundle on host path (#478)
* 7b409ed Fix cert-manager upstream authority when enabling recommendations (#476)
* 01c7227 Add support for the new fallback spire-controller-manager feature (#471)
* 0a6dd19 Bump test chart dependencies (#477)
* fcbd64e Support federation bundle endpoint profile http_web certificates (#469)
* c29f45f Add AWS DB types (#464)
* 898a349 Add remaining data store options (#463)
* 2443515 Bump test chart dependencies (#474)
* c461794 Update the spire-controller-manager to 0.6.0 (#473)
* 5d07eaf Align more settings to convention (#467)
* ea2d673 Bump test chart dependencies (#470)
* 352aee2 Bump test chart dependencies (#468)
* c3c8514 Change curl --caPath to --capath (#462)
* 68d21cc Add an initial json schema file for spire-agent (#458)
* b7e9823 Add new config.jwtDomain value to oidc-discovery chart (#457)
* 8832da3 Protects SPIRE Agent's Chart Against YAML Template Injection (#450)
* 3bc7025 Update spiffe-helper (#453)
* 86d6fca Bump test chart dependencies (#449)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* a7368ee Upgrade to spire 1.11.0 (#483)
* 5d07eaf Align more settings to convention (#467)
