### PR TITLE
Fix GCS Bundle endpoint format variable

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -307,7 +307,7 @@ plugins:
       plugin_data:
         bucket_name: {{ .Values.bundlePublisher.gcpCloudStorage.bucketName | quote }}
         object_name: {{ .Values.bundlePublisher.gcpCloudStorage.objectName | quote }}
-        format: {{ .Values.bundlePublisher.awsS3.format | quote }}
+        format: {{ .Values.bundlePublisher.gcpCloudStorage.format | quote }}
     {{- end }}
   {{- end }}
 


### PR DESCRIPTION
The GCS Bundle endpoint configuration was pointing to the S3 Format variable instead of the GCS one.