### PR TITLE
Bump spire-nested Helm Chart version from 0.24.1 to 0.24.2

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.24.1
+version: 0.24.2
 appVersion: "1.11.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.24.1](https://img.shields.io/badge/Version-0.24.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
+![Version: 0.24.2](https://img.shields.io/badge/Version-0.24.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire

* b13f4c0 Bump test chart dependencies
* 915744f Bump test chart dependencies (#529)
* 0368210 Update spire to 1.11.2 (#527)
* ea03059 Bump test chart dependencies (#524)
* 762ba40 Bump test chart dependencies (#523)
* f1ba4ba Bump test chart dependencies (#522)
* 413e579 Bump test chart dependencies
* f88e3d5 Bump test chart dependencies (#517)
* 848f491 Bump test chart dependencies (#516)
* 41cbad2 Bump test chart dependencies (#512)
* 8925ed6 Bump test chart dependencies (#508)
* 70f5b19 Bump test chart dependencies (#500)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 0368210 Update spire to 1.11.2 (#527)
