### PR TITLE
Bump spire Helm Chart version from 0.24.2 to 0.24.3

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.24.2
+version: 0.24.3
 appVersion: "1.12.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.24.2](https://img.shields.io/badge/Version-0.24.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 0.24.3](https://img.shields.io/badge/Version-0.24.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-nested

* 663b89e3 Upgrade to SPIRE 1.12.0 (#542)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 25967bae Add new config.jwksUri option to oidc-discovery chart (#547)
* 2f96b0b1 Bump test chart dependencies (#545)
* 663b89e3 Upgrade to SPIRE 1.12.0 (#542)
* 1c73035e Add values to configure apiServiceLabel and webhookLabel (#536)
* 385cbb3e Bump test chart dependencies (#539)
* ad44c486 Bump test chart dependencies (#537)
* 86ea90cb Fixes indentation of sync_interval value inside spire-agent configmap (#534)
* 3940ac3c Bump test chart dependencies (#533)
