### PR TITLE
Bump spire-nested Helm Chart version from 0.24.5 to 0.25.0

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.24.5
+version: 0.25.0
 appVersion: "1.12.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.24.5](https://img.shields.io/badge/Version-0.24.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.2](https://img.shields.io/badge/AppVersion-1.12.2-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.2](https://img.shields.io/badge/AppVersion-1.12.2-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire

* bd2e8e3 Update spire to 1.12.2 (#592)
* d6684bc Add spire-credentialcomposer-cel support (#587)
* ccfb490 Dynamically build the connection_string with options for the spire server when spire-server.dataStore.sql.databaseType == sqlite3 (#576)
* 87bef26 Bump test chart dependencies (#588)
* b72505b Bump test chart dependencies (#580)
* e4bd1df Bump spire to 1.12.1 (#578)
* 9062710 Bump test chart dependencies (#575)
* 94e1d78 Bump test chart dependencies (#573)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* bd2e8e3 Update spire to 1.12.2 (#592)
* e4bd1df Bump spire to 1.12.1 (#578)
