### PR TITLE
Fix: Spire Agent securityContext issue

### DIFF
--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -58,8 +58,8 @@ securityContext: {}
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  # runAsNonRoot: true # WARNING: Setting this to `true` will likely cause the Spire Agent to fail.
+  runAsUser: 0 # Spire Agent typically requires root (UID 0) to function correctly.
 
 ## @param resources [object] Resource requests and limits
 resources: {}


### PR DESCRIPTION
The upstream Spire Agent [Dockerfile](https://github.com/spiffe/spire/blob/main/Dockerfile#L72) defaults to running as the root user (UID 0). When the spec enforces `runAsNonRoot: true` and/or `runAsUser: 1000` via the `securityContext`, the Spire Agent container will fail with errors like: `container has runAsNonRoot and image will run as root`.

Fix: Explicitly set the `runAsUser: 0` so it is clear that we are running it as root. Also add a warning that, setting `runAsNonRoot` to true will cause errors. Open to better solutions, just looking to avoid confusion.