### PR TITLE
Bump spire Helm Chart version from 0.26.0 to 0.26.1

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.26.0
+version: 0.26.1
 appVersion: "1.12.4"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.4](https://img.shields.io/badge/AppVersion-1.12.4-informational?style=flat-square)
+![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.4](https://img.shields.io/badge/AppVersion-1.12.4-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spiffe-step-ssh

* a7d536c tools: Replace rancher/kubectl with registry.k8s.io/kubectl

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spiffe-step-ssh --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 64b9c40 Bump test chart dependencies (#635)
* d516de0 Update spike to 0.4.2 (#632)
* 8904b96 Bump test chart dependencies (#633)
* 6581b11 Add disk based KeyManager (#627)
* d2913ff Remove region from awsiid node attestor (#630)
* 3218db7 Bump test chart dependencies (#628)
* 57a6143 Add aws_iid to helm chart (#620)
* 9a8e5a8 Add Agent TTL to Spire Server (#626)
* 093c593 spire-server: Replace chown image with busybox
* a7d536c tools: Replace rancher/kubectl with registry.k8s.io/kubectl
* fc1791f Bump test chart dependencies (#618)
