### PR TITLE
WIP: Add Datadog as telemetry option

### DIFF
--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -170,6 +170,13 @@ telemetry:
       - host: "0.0.0.0"
         port: {{ .Values.telemetry.prometheus.port }}
 {{- end }}
+
+{{- if .Values.telemetry.datadog.enabled }}
+telemetry:
+  - DogStatsd:
+      - address: "{{ .Values.telemetry.datadog.address }}:{{ .Values.telemetry.datadog.port }}"
+{{- end }}
+
 {{- end }}
 {{- $root := . }}
 {{- range $name := (concat (list "default") (keys .Values.agents)) | uniq }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -263,6 +263,13 @@ telemetry:
       namespace: ""
       ## @param telemetry.prometheus.podMonitor.labels [object] Pod labels to filter for prometheus monitoring
       labels: {}
+  datadog:
+    ## @param telemetry.datadog.enabled Flag to enable datadog monitoring
+    enabled: false
+    ## @param telemetry.datadog.address The address of the datadog agent to send metrics to
+    address: "v-datadog.kube-system.svc.cluster.local"
+    ## @param telemetry.datadog.port The port of the datadog agent to send metrics to
+    port: 8125
 
 ## @param kubeletConnectByHostname If true, connect to kubelet using the nodes hostname. If false, uses localhost. If unset, defaults to true on OpenShift and false otherwise.
 kubeletConnectByHostname: ""

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -499,6 +499,13 @@ telemetry:
       - host: "0.0.0.0"
         port: 9988
 {{- end }}
+
+{{- if .Values.telemetry.datadog.enabled }}
+telemetry:
+  - DogStatsd:
+      - address: "{{ .Values.telemetry.datadog.address }}:{{ .Values.telemetry.datadog.port }}"
+{{- end }}
+
 {{- end }}
 {{- if not .Values.externalServer }}
 apiVersion: v1

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -852,6 +852,13 @@ telemetry:
       namespace: ""
       ## @param telemetry.prometheus.podMonitor.labels [object] Pod labels to filter for prometheus monitoring
       labels: {}
+  datadog:
+    ## @param telemetry.datadog.enabled Flag to enable datadog monitoring
+    enabled: false
+    ## @param telemetry.datadog.address The address of the datadog agent to send metrics to
+    address: "v-datadog.kube-system.svc.cluster.local"
+    ## @param telemetry.datadog.port The port of the datadog agent to send metrics to
+    port: 8125
 
 ingress:
   ## @param ingress.enabled Flag to enable ingress


### PR DESCRIPTION
This pull request introduces support for Datadog telemetry in the SPIRE Helm charts, allowing metrics to be sent to a Datadog agent. The changes include updates to both the `spire-agent` and `spire-server` configurations to enable this feature.

### Datadog Telemetry Support:

* **SPIRE Agent Configuration:**
  - Added conditional logic in `charts/spire/charts/spire-agent/templates/configmap.yaml` to configure Datadog telemetry when enabled. (`[charts/spire/charts/spire-agent/templates/configmap.yamlR173-R179](diffhunk://#diff-f58659011443739214c084a2e94b27a58e4815c45b5ac6a6ea4d23c116e97845R173-R179)`)
  - Introduced new parameters in `charts/spire/charts/spire-agent/values.yaml` to control Datadog telemetry, including enabling/disabling it, specifying the Datadog agent address, and setting the port. (`[charts/spire/charts/spire-agent/values.yamlR266-R272](diffhunk://#diff-73ab6798fce1b72119a73440f02450a16fd62235f732b2ed12d69c2cf7695883R266-R272)`)

* **SPIRE Server Configuration:**
  - Added conditional logic in `charts/spire/charts/spire-server/templates/configmap.yaml` to configure Datadog telemetry when enabled. (`[charts/spire/charts/spire-server/templates/configmap.yamlR502-R508](diffhunk://#diff-95a921e948f7af4dcca64089a1d722399e1ab49bf5b42f420c6ee4f42c3cdd25R502-R508)`)
  - Introduced new parameters in `charts/spire/charts/spire-server/values.yaml` to control Datadog telemetry, including enabling/disabling it, specifying the Datadog agent address, and setting the port. (`[charts/spire/charts/spire-server/values.yamlR855-R861](diffhunk://#diff-2970cff31c683ad68e57af57ddbb9acf98765a7898efdeff84c8532c260e1dcbR855-R861)`)