### PR TITLE
Bump spiffe-step-ssh Helm Chart version from 0.1.0 to 0.1.1

### DIFF
--- a/charts/spiffe-step-ssh/Chart.yaml
+++ b/charts/spiffe-step-ssh/Chart.yaml
@@ -35,7 +35,7 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire/charts/spire-lib
-    version: 0.1.1
+    version: 0.1.0
   - name: step-certificates
     alias: step
     repository: https://smallstep.github.io/helm-charts/

--- a/charts/spiffe-step-ssh/Chart.yaml
+++ b/charts/spiffe-step-ssh/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,7 +35,7 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire/charts/spire-lib
-    version: 0.1.0
+    version: 0.1.1
   - name: step-certificates
     alias: step
     repository: https://smallstep.github.io/helm-charts/


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-nested

* 28c65d34 Bump spire-nested Helm Chart version from 0.26.0 to 0.26.1 (#637)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --new-version ………
```
### Unreleased changes spire

* acfcc9d0 Bump spire Helm Chart version from 0.26.0 to 0.26.1 (#636)
* 64b9c400 Bump test chart dependencies (#635)
* d516de01 Update spike to 0.4.2 (#632)
* 8904b96b Bump test chart dependencies (#633)
* 6581b117 Add disk based KeyManager (#627)
* d2913ffc Remove region from awsiid node attestor (#630)
* 3218db7b Bump test chart dependencies (#628)
* 57a61438 Add aws_iid to helm chart (#620)
* 9a8e5a83 Add Agent TTL to Spire Server (#626)
* 093c593f spire-server: Replace chown image with busybox
* a7d536c0 tools: Replace rancher/kubectl with registry.k8s.io/kubectl
* fc1791f2 Bump test chart dependencies (#618)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* a7d536c0 tools: Replace rancher/kubectl with registry.k8s.io/kubectl
