### PR TITLE
Support for Cloud SQL Proxy in GCP

### DIFF
--- a/charts/spire/charts/spire-server/templates/secret.yaml
+++ b/charts/spire/charts/spire-server/templates/secret.yaml
@@ -8,7 +8,7 @@
 {{- fail "dataStore.sql.externalSecret.key cannot be empty string when dataStore.sql.externalSecret is enabled" }}
 {{- end }}
 {{- if ne .Values.dataStore.sql.databaseType "sqlite3" }}
-{{- if not .Values.dataStore.sql.externalSecret.enabled }}
+{{- if and (not .Values.dataStore.sql.externalSecret.enabled) (not .Values.dataStore.sql.iamAuth) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/spire/charts/spire-server/templates/server-resource.yaml
+++ b/charts/spire/charts/spire-server/templates/server-resource.yaml
@@ -229,7 +229,9 @@ spec:
           {{- . | toYaml | nindent 10 }}
           {{- end }}
           {{- if ne .Values.dataStore.sql.databaseType "sqlite3" }}
-          {{- if .Values.dataStore.sql.externalSecret.enabled }}
+          {{- if .Values.dataStore.sql.iamAuth }}
+          # No DBPW environment variable needed for IAM authentication
+          {{- else if .Values.dataStore.sql.externalSecret.enabled }}
           - name: DBPW
             valueFrom:
               secretKeyRef:
@@ -242,18 +244,22 @@ spec:
                 name: {{ $fullname }}-dbpw
                 key: DBPW
           {{- end }}
-          {{- if and .Values.dataStore.sql.readOnly.enabled .Values.dataStore.sql.readOnly.externalSecret.enabled }}
+          {{- if .Values.dataStore.sql.readOnly.enabled }}
+          {{- if .Values.dataStore.sql.iamAuth }}
+          # No RODBPW environment variable needed for IAM authentication
+          {{- else if .Values.dataStore.sql.readOnly.externalSecret.enabled }}
           - name: RODBPW
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.dataStore.sql.readOnly.externalSecret.name }}
                 key: {{ .Values.dataStore.sql.readOnly.externalSecret.key }}
-          {{- else if .Values.dataStore.sql.readOnly.enabled }}
+          {{- else }}
           - name: RODBPW
             valueFrom:
               secretKeyRef:
                 name: {{ $fullname }}-dbpw
                 key: RODBPW
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- if ne .Values.keyManager.awsKMS.accessKeyID "" }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -179,6 +179,9 @@ dataStore:
     ## @param dataStore.sql.clientKeyPath Path to private key for client certificate (MySQL only)
     clientKeyPath: ""
 
+    ## @param dataStore.sql.iamAuth Enable IAM authentication for Cloud SQL (MySQL only). When enabled, password will be excluded from connection string.
+    iamAuth: false
+
     ## When an external source creates the secret. The secret should reside in the same namespace as the spire server
     externalSecret:
       ## @param dataStore.sql.externalSecret.enabled Enable external secret for datastore creds


### PR DESCRIPTION
## Support for Cloud SQL Proxy in GCP

This change adds configuration to enable [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy) support for the `spire-server` Helm chart when running in GCP.  
It leverages **IAM authentication** instead of static credentials, improving security and simplifying secrets management.

**Reference:**  
- [Cloud SQL Auth Proxy Documentation](https://cloud.google.com/sql/docs/mysql/sql-proxy)
- [Blog Example from Google](https://cloud.google.com/blog/products/databases/application-security-with-cloud-sql-iam-database-authentication)

<details>
<summary>Example Usage</summary>

````yaml
spire-server:
  serviceAccount:
    create: true
    annotations:
      iam.gke.io/gcp-service-account: "<SERVICE_ACCOUNT>@<PROJECT_ID>.iam.gserviceaccount.com"
    name: "<SERVICE_ACCOUNT>"
  
  extraContainers:
    - name: cloud-sql-proxy
      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
      args:
        - "--auto-iam-authn"
        - "--structured-logs"
        - "--port=3306"
        - "<PROJECT_ID>:<REGION>:<DATABASE_INSTANCE_NAME>"

      env:
        - name: GOOGLE_CLOUD_PROJECT
          value: "<PROJECT_ID>"
        - name: GOOGLE_CLOUD_REGION
          value: "<REGION>"

      securityContext:
        runAsNonRoot: true
        runAsUser: 65532
        runAsGroup: 65532
        allowPrivilegeEscalation: false
        capabilities:
          drop: ["ALL"]
        seccompProfile:
          type: RuntimeDefault
  
  dataStore:
    sql:
      databaseType: mysql
      databaseName: spire
      host: 127.0.0.1
      port: 3306
      username: "<SERVICE_ACCOUNT>"
      password: ""
      iamAuth: true
      options: []
      externalSecret:
        enabled: false
        name: ""
        key: ""
