### PR TITLE
Bump spire-nested Helm Chart version from 0.26.1 to 0.27.0

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.26.1
+version: 0.27.0
 appVersion: "1.13.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire

* e73d76a0 Bump test chart dependencies (#669)
* 1ab06a1b Support for Cloud SQL Proxy in GCP (#646)
* 3c3718c9 Update spire to 1.13.0 (#667)
* 1feeca1c make spire server's auth_opa_policy_engine configurable in the helm chart (#663)
* d51bf52a Bump test chart dependencies (#666)
* c1b0cfe3 Add controller manager configs gcInterval, logLevel, and make entryIDPrefix configurable (#662)
* bb876121 Spire agent helm chart: allow configuring logFormat (#661)
* d6edae68 Add labels to the spiffe-oidc-discovery-provider values.yaml (#656)
* 6376190b Bump test chart dependencies (#660)
* 9a802563 Bump test chart dependencies (#658)
* 5e5810be Bump test chart dependencies (#653)
* 86feac63 Bump test chart dependencies (#647)
* 5e40cfb2 Update imagePullPolicy to IfNotPresent (#643)
* 86f0aecc Bump test chart dependencies (#641)
* 3ef5fe6c Add Datadog as telemetry option (#639)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 3c3718c9 Update spire to 1.13.0 (#667)
