### PR TITLE
chore: fix gha tests referencing bitnami images

### DIFF
--- a/.github/tests/dependencies/mysql.yaml
+++ b/.github/tests/dependencies/mysql.yaml
@@ -10,3 +10,9 @@ auth:
   username: spire
   password: sp1ff3Test
   rootPassword: sp1ff3TestPassword
+image:
+  repository: bitnamilegacy/mysql
+global:
+  security:
+    # required to use bitnamilegacy images
+    allowInsecureImages: true

--- a/.github/tests/dependencies/postgresql.yaml
+++ b/.github/tests/dependencies/postgresql.yaml
@@ -11,3 +11,9 @@ auth:
   username: spire
   password: sp1ff3Test
   postgresPassword: sp1ff3TestPassword
+image:
+  repository: bitnamilegacy/postgresql
+global:
+  security:
+    # required to use bitnamilegacy images
+    allowInsecureImages: true


### PR DESCRIPTION
Bitnami stopped releasing some images and moved the archival images to bitnamilegacy namespace.

The best fix would be to migrate away from bitnami charts but it would need more engineering.

This change switches to use bitnamilegacy in the meantime.