### PR TITLE
Refactor configmap.yaml to handle plugin checksums and missing implementation

### DIFF
--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -9,9 +9,7 @@
 {{-     if not (hasKey $nval "plugin_cmd") }}
 {{-       fail (printf "plugin_cmd is a required field. %s" $name) }}
 {{-     end }}
-{{-     if not (hasKey $nval "plugin_checksum") }}
-{{-       fail (printf "plugin_checksum is a required field.") }}
-{{-     end }}
+{{-     $_ := set $ "checksum_warning" (not (hasKey $nval "plugin_checksum")) }}
 {{-     range $sname, $svals := $nval }}
 {{-       if not (has $sname (list "plugin_cmd" "plugin_checksum" "plugin_data")) }}
 {{-         fail (printf "Unknown plugin setting specified: %s" $sname) }}
@@ -70,7 +68,7 @@ agent:
     {{- if gt (len .featureFlags) 0 }}
     feature_flags:
       {{- range .featureFlags }}
-        - {{ . | quote }}
+      - {{ . | quote }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -116,6 +114,18 @@ plugins:
     {{- $nodeAttestorUsed = add1 $nodeAttestorUsed }}
     {{- end }}
     {{- end }}
+
+  {{- range $name, $plugin := .Values.customPlugins.nodeAttestor }}
+    {{ $name }}:
+    plugin_cmd: {{ $plugin.plugin_cmd | quote }}
+    plugin_checksum: {{ $plugin.plugin_checksum | quote }}
+      {{- if $plugin.plugin_data }}
+    plugin_data:
+        {{- toYaml $plugin.plugin_data | nindent 8 }}
+      {{- end }}
+    {{- $nodeAttestorUsed = add1 $nodeAttestorUsed }}
+  {{- end }}
+
 {{- if ne $nodeAttestorUsed 1 }}
 {{- fail (printf "You have to enable exactly one Node Attestor. There are %d enabled." $nodeAttestorUsed) }}
 {{- end }}
@@ -132,6 +142,18 @@ plugins:
         directory: {{ .Values.persistence.hostPath }}
     {{- $keyManagerUsed = add1 $keyManagerUsed }}
     {{- end }}
+
+  {{- range $name, $plugin := .Values.customPlugins.keyManager }}
+    {{ $name }}:
+    plugin_cmd: {{ $plugin.plugin_cmd | quote }}
+    plugin_checksum: {{ $plugin.plugin_checksum | quote }}
+      {{- if $plugin.plugin_data }}
+    plugin_data:
+        {{- toYaml $plugin.plugin_data | nindent 8 }}
+      {{- end }}
+    {{- $keyManagerUsed = add1 $keyManagerUsed }}
+  {{- end }}
+
 {{- if ne $keyManagerUsed 1 }}
 {{- fail (printf "You have to enable exactly one Key Manager. There are %d enabled." $keyManagerUsed) }}
 {{- end }}
@@ -157,6 +179,18 @@ plugins:
   {{- if .Values.workloadAttestors.unix.enabled }}
     unix:
       plugin_data:
+  {{- end }}
+
+  {{- range $name, $plugin := .Values.customPlugins.workloadAttestor }}
+    {{ $name }}:
+    plugin_cmd: {{ $plugin.plugin_cmd | quote }}
+      {{- if $plugin.plugin_checksum }}
+    plugin_checksum: {{ $plugin.plugin_checksum | quote }}
+      {{- end }}
+      {{- if $plugin.plugin_data }}
+    plugin_data:
+        {{- toYaml $plugin.plugin_data | nindent 8 }}
+      {{- end }}
   {{- end }}
 
 health_checks:


### PR DESCRIPTION
### **What this PR does**

This PR improves the SPIRE Agent Helm chart by actually **implementing support for custom plugins** and making plugin validation less strict.

The `values.yaml` already had fields for custom plugins, but they were never actually used — this fixes that.

---

### **Custom plugin support**

You can now define your own plugins in `values.yaml` for:

* **Node Attestor plugins** (`.Values.customPlugins.nodeAttestor`)
* **Key Manager plugins** (`.Values.customPlugins.keyManager`)
* **Workload Attestor plugins** (`.Values.customPlugins.workloadAttestor`)

For each plugin, you can specify:

* `plugin_cmd` (required)
* `plugin_checksum` (optional)
* `plugin_data` (optional)

This makes all the previously declared values actually work.

---

### **Validation changes**

Before, the template would fail if `plugin_checksum` was missing:

```gotemplate
{{- if not (hasKey $nval "plugin_checksum") }}
{{-   fail (printf "plugin_checksum is a required field.") }}
{{- end }}
```

Now it just sets a flag:

```gotemplate
{{- $_ := set $ "checksum_warning" (not (hasKey $nval "plugin_checksum")) }}
```

* The template won’t fail if `plugin_checksum` is missing.
* The flag can be used later to show a warning or fallback.
* Basically, it’s optional from the agent prespective, which makes the chart compaitable with the agent's configuration.
