### PR TITLE
Fix keyManager check stopping use of other plugins

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -298,6 +298,8 @@ plugins:
   {{- end }}
   {{- end }}
 
+{{- $keyManagerUsed = add $keyManagerUsed (len .Values.unsupportedBuiltInPlugins.keyManager) }}
+
 {{- if ne $keyManagerUsed 1 }}
 {{- fail (printf "You have to enable exactly one Key Manager. There are %d enabled." $keyManagerUsed) }}
 {{- end }}


### PR DESCRIPTION
Fixes point 1 of https://github.com/spiffe/helm-charts-hardened/issues/714

Adds unsupported built-in plugins (built-in plugins that do not have direct toggles in the helm chart) to the check that exactly one key manager plugin is enabled - the previous check only allowed usage of key manager plugins with explicit values in the helm chart.
    
This still doesn't allow usage of custom key manager plugins - as they will not be present in the count that is checked.

A more complete fix (as noted in the linked issue) would be to do a check elsewhere that accounts for built-in, unsupported built-in and custom plugins - but since that is more work and likely to invoke more discussion (e.g. about where to put that logic or even if it should exist) this PR just resolves point 1 on the issue by including the unsupported built-in plugins in the count that is checked.