### PR TITLE
Bump spire-nested Helm Chart version from 0.27.1 to 0.28.0

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.27.1
+version: 0.28.0
 appVersion: "1.14.1"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.1](https://img.shields.io/badge/AppVersion-1.14.1-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.1](https://img.shields.io/badge/AppVersion-1.14.1-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire

* 6f2c71b0 Update spire to 1.14.1 (#729)
* f8f1e21f CSI driver: Support setting podSecurityContext and securityContext (#642)
* 813203a4 Update spike to the newest version (#665)
* 97c383b1 Add Configurable Kubelet Address for SPIRE Agent (#709)
* 8555efc6 Bump test chart dependencies
* e6c9d975 Bump test chart dependencies
* 87da80a8 Add support for AWS KMS key tagging (#721)
* db8f1352 Bump test chart dependencies (#720)
* b1f902b6 Bump test chart dependencies
* 198cdb60 Bump test chart dependencies
* dfbbecf0 Add guard to the validating admission policy to stop errors when there are no volumes in the spec. This fixes errors with HTTP solver pods in cert manager. (#706)
* 1e1e8daa Add support for attested node pruning configuration (#713)
* a2130ff7 Bump test chart dependencies (#712)
* adc5f3e8 Bump test chart dependencies
* 4e0cdb13 Bump test chart dependencies
* 95fa0deb Allow configuring spire-agent prometheus listening address (#701)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 6f2c71b0 Update spire to 1.14.1 (#729)
