### PR TITLE
Bump CI to last 3 k8s minors

### DIFF
--- a/.github/workflows/helm-chart-ci-ignore.yaml
+++ b/.github/workflows/helm-chart-ci-ignore.yaml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - run: 'echo "Skipping tests"'
@@ -74,9 +74,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
         example:
           - ${{ fromJson(needs.build-matrix.outputs.examples) }}
 
@@ -92,9 +92,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
         example:
           - ${{ fromJson(needs.build-matrix.outputs.integrationtests) }}
 
@@ -110,9 +110,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - run: 'echo "Skipping upgrade-test"'

--- a/.github/workflows/helm-chart-ci.yaml
+++ b/.github/workflows/helm-chart-ci.yaml
@@ -2,6 +2,11 @@ name: Helm Chart CI
 
 on:
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch to lint/test against (e.g. main, release)'
+        required: false
+        default: 'main'
   pull_request:
     types: [synchronize, opened, reopened]
     paths:
@@ -114,7 +119,7 @@ jobs:
           version: ${{ env.CHART_TESTING_VERSION }}
 
       - name: Run chart-testing (lint)
-        run: TARGET_BRANCH=${{ github.base_ref }} make lint${{ github.base_ref == 'release' && '-release' || '' }}
+        run: TARGET_BRANCH=${{ github.base_ref || inputs.target_branch }} make lint${{ (github.base_ref == 'release' || inputs.target_branch == 'release') && '-release' || '' }}
 
   test:
     runs-on: ubuntu-22.04
@@ -130,9 +135,9 @@ jobs:
         # Kubernetes, but can go back farther as long as we don't need heroics
         # to pull it off (i.e. kubectl version juggling).
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout
@@ -172,7 +177,7 @@ jobs:
         run: |
           helm install -n spire-server spire-crds charts/spire-crds
           ct install --config ct.yaml --excluded-charts spire-crds,spiffe-step-ssh \
-            --target-branch ${{ github.base_ref }}
+            --target-branch ${{ github.base_ref || inputs.target_branch }}
 
       - name: Test summary
         if: always()
@@ -218,9 +223,9 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
         example:
           - ${{ fromJson(needs.build-matrix.outputs.examples) }}
 
@@ -270,9 +275,9 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
         integrationtest:
           - ${{ fromJson(needs.build-matrix.outputs.integrationtests) }}
 
@@ -315,9 +320,9 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
-          - v1.31.1
-          - v1.30.4
-          - v1.29.8
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
> [!Note]
> Also fixed the manual `workflow_dispatch`. See https://github.com/spiffe/helm-charts-hardened/actions/runs/22569242395

> The problem is `github.base_ref` is only populated for `pull_request` events — it's empty on `workflow_dispatch`.                                                                  
>                                                                                                                                                                               
> This affects two places:                                                                                                                                                     
> - Line 117: TARGET_BRANCH becomes empty, and the make lint/make lint-release conditional breaks                                                                              
> - Line 175: --target-branch also gets an empty value

> [!Important]
> Before merging this PR we will also have to update the branch protection to match the new required job names.