### PR TITLE
Fix agent.conf generation logic for SVIDStore

### DIFF
--- a/charts/spire-lib/templates/_helpers.tpl
+++ b/charts/spire-lib/templates/_helpers.tpl
@@ -202,7 +202,7 @@ Take a copy of the config and merge in .Values.customPlugins and .Values.unsuppo
 {{- $pluginsToMerge := dict "plugins" dict }}
 {{- range $type, $val := .root.Values.customPlugins }}
 {{-   if . }}
-{{-     if eq $type "svidstore" }}
+{{-     if eq $type "svidStore" }}
 {{-       $_ := set $pluginsToMerge.plugins "SVIDStore" (deepCopy $val) }}
 {{-     else }}
 {{-       $nt := printf "%s%s" (substr 0 1 $type | upper) (substr 1 -1 $type) }}
@@ -212,7 +212,7 @@ Take a copy of the config and merge in .Values.customPlugins and .Values.unsuppo
 {{- end }}
 {{- range $type, $val := .root.Values.unsupportedBuiltInPlugins }}
 {{-   if . }}
-{{-     if eq $type "svidstore" }}
+{{-     if eq $type "svidStore" }}
 {{-       $_ := set $pluginsToMerge.plugins "SVIDStore" (deepCopy $val) }}
 {{-     else }}
 {{-       $nt := printf "%s%s" (substr 0 1 $type | upper) (substr 1 -1 $type) }}


### PR DESCRIPTION
Fix the casing of "svidstore" to "svidStore" in the configuration merging logic for `agent.conf`.

It previously created invalid configuration for SVIDStore by falling through to the `else` branch of the condition and generating PascalCased `SvidStore` thus  causing the `spire-agent` to be stuck in CrashLoopBackOff.

```
spire-agent time="2026-04-09T09:40:31.607601422Z" level=error msg="Agent crashed" error="unsupported plugin type \"SvidStore\""
```

This corrects the logic so the correct `SVIDStore` key is geneated in `agent.conf`.
