### PR TITLE
Bump spire-nested Helm Chart version from 0.28.3 to 0.28.4

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -3,7 +3,7 @@ name: spire-nested
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.28.3
+version: 0.28.4
 appVersion: "1.14.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.28.3](https://img.shields.io/badge/Version-0.28.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.5](https://img.shields.io/badge/AppVersion-1.14.5-informational?style=flat-square)
+![Version: 0.28.4](https://img.shields.io/badge/Version-0.28.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.5](https://img.shields.io/badge/AppVersion-1.14.5-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spiffe-step-ssh

* 9273f11f Support root-level spire-lib chart reuse (#785)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spiffe-step-ssh --new-version ………
```
### Unreleased changes spire

* 01342172 Fix typos in error messages (#788)
* 040ccf90 Bump versions to 1.14.5 (#789)
* 9273f11f Support root-level spire-lib chart reuse (#785)
* 145f3a36 chore: Add configurable probes for controller-manager (#784)
* a27acbcb Bump test chart dependencies (#786)
* 838a3535 Label chart (#783)
* 59de7aa3 Bump test chart dependencies (#779)
* 96773a31 Bump versions (#777)
* aad7527c Add set_key_use configuration option (#774)
* de59147f fix gather hostcert edge case issues (#775)
* bf4bd819 feature: add awsSecretsManager upstreamAuthority (#772)
* f78c1d42 Bump test chart dependencies (#773)
* 7afffd75 Bump test chart dependencies (#771)
* 60899fc9 Add configurable hostNetwork support to spiffe-csi-driver (#769)
* 2de363a4 Bump test chart dependencies (#767)
* 6631349b feat(spire-server): add logEncoding parameter for controller-manager (#766)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --new-version ………
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Changes in this release

* 86787b59 Add initial spire-ha-agent support to the spire-nested chart (#790)
* 040ccf90 Bump versions to 1.14.5 (#789)
* 9273f11f Support root-level spire-lib chart reuse (#785)
* 96773a31 Bump versions (#777)
