### PR TITLE
allow unsupported built-in key manager plugins to be used

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -322,7 +322,11 @@ plugins:
   {{- end }}
   {{- end }}
 
-{{- $keyManagerUsed = add $keyManagerUsed (len .Values.unsupportedBuiltInPlugins.keyManager) }}
+{{- if .Values.unsupportedBuiltInPlugins.keyManager }}
+{{- $keyManagerUsed = add $keyManagerUsed 1 }}
+  KeyManager:
+    {{- .Values.unsupportedBuiltInPlugins.keyManager | toYaml | nindent 4 }}
+{{- end }}
 
 {{- if ne $keyManagerUsed 1 }}
 {{- fail (printf "You have to enable exactly one Key Manager. There are %d enabled." $keyManagerUsed) }}


### PR DESCRIPTION
currently the field `spire-server.unsupportedBuiltInPlugins.keyManager` exists but all it does is cause the chart templating to fail if it is set and another keymanager is enabled. I would like the ability to actually use its values.

Specifically, I want the ability to use the gcp_kms or azure_key_vaults plugins. I imagine I will make a PR later to add actual support for those. But we need this change on a quicker timeline than what it would take to do that properly and give enough of a buffer for the chart to have a new release so we can use the official version, so I would prefer to get this in and revisit it later.