### PR TITLE
fix: workaround for SPIRE Controller Manager log config disrespect

### DIFF
--- a/charts/spire/charts/spire-server/templates/_controller-manager-container.tpl
+++ b/charts/spire/charts/spire-server/templates/_controller-manager-container.tpl
@@ -109,6 +109,9 @@ Auto-generation preserves trailing numbers from cluster names or uses hash for u
     {{- if $expandEnv }}
     - --expand-env
     {{- end }}
+    # Workaround until https://github.com/spiffe/spire-controller-manager/pull/667 is fixed.
+    - --zap-encoder={{ .Values.controllerManager.logEncoding }}
+    - --zap-log-level={{ .Values.controllerManager.logLevel }}
   env:
     - name: ENABLE_WEBHOOKS
     {{- if eq .Values.controllerManager.staticManifestMode "off" }}

--- a/charts/spire/charts/spire-server/templates/controller-manager-configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/controller-manager-configmap.yaml
@@ -49,9 +49,7 @@ health:
   healthProbeBindAddress: 0.0.0.0:{{ $healthPort }}
 gcInterval: {{ .Values.controllerManager.gcInterval }}
 logLevel: {{ .Values.controllerManager.logLevel }}
-{{- with .Values.controllerManager.logEncoding }}
-logEncoding: {{ . }}
-{{- end }}
+logEncoding: {{ .Values.controllerManager.logEncoding }}
 {{- if eq .Values.controllerManager.staticManifestMode "off" }}
 leaderElection:
   leaderElect: true


### PR DESCRIPTION
Upstream bug that CM only respects logger configuration from CLI, not fixed yet: https://github.com/spiffe/spire-controller-manager/pull/667.

Without patch:

<img width="2477" height="904" alt="image" src="https://github.com/user-attachments/assets/5511dfbe-d6df-4723-bc7c-3886ec92d8ea" />

With patch:

<img width="1394" height="843" alt="image" src="https://github.com/user-attachments/assets/9a4ecb78-ad2d-44b5-aacc-b66c861ff748" />
