### PR TITLE
feat(spire-agent): add x509_svid_cache_max_size and jwt_svid_cache_max_size config

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,7 @@ name: spire
 description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 type: application
-version: 0.28.5
+version: 0.28.6
 appVersion: "1.14.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -65,6 +65,12 @@ agent:
   {{- with .Values.availabilityTarget }}
   availability_target: {{ . | quote }}
   {{- end }}
+  {{- if gt (int .Values.x509SvidCacheMaxSize) 0 }}
+  x509_svid_cache_max_size: {{ .Values.x509SvidCacheMaxSize }}
+  {{- end }}
+  {{- if gt (int .Values.jwtSvidCacheMaxSize) 0 }}
+  jwt_svid_cache_max_size: {{ .Values.jwtSvidCacheMaxSize }}
+  {{- end }}
   {{- if .Values.sds.enabled }}
   sds:
     default_svid_name: {{ .Values.sds.defaultSVIDName | quote }}

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -103,6 +103,10 @@ trustBundleHostPath: ""
 bundleConfigMap: spire-bundle
 ## @param availabilityTarget The minimum amount of time desired to gracefully handle SPIRE Server or Agent downtime. This configurable influences how aggressively X509 SVIDs should be rotated. If set, must be at least 24h.
 availabilityTarget: ""
+## @param x509SvidCacheMaxSize The maximum number of X.509 SVIDs to cache. Set to 0 to use the SPIRE default.
+x509SvidCacheMaxSize: 1000
+## @param jwtSvidCacheMaxSize The maximum number of JWT SVIDs to cache. Set to 0 to use the SPIRE default.
+jwtSvidCacheMaxSize: 1000
 ## @param rebootstrapMode How the agent will behave when seeing an unknown x509 cert from the server. It can be set to never, auto, or always
 rebootstrapMode: always
 ## @param rebootstrapDelay The agent will rebootstrap after configured amount of time on unknown x509 cert from the server


### PR DESCRIPTION
## Summary
- Expose `x509_svid_cache_max_size` and `jwt_svid_cache_max_size` as configurable values in the spire-agent chart, defaulting to 1000.
- Emit the fields into the agent ConfigMap only when the value is non-zero (set to 0 to fall back to the SPIRE binary default).