### PR TITLE
Add Smallstep repo to release workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -38,6 +38,10 @@ jobs:
         with:
           version: v3.10.3
 
+      - name: Add required Helm repos for release packaging
+        run: |
+          helm repo add smallstep https://smallstep.github.io/helm-charts/
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:


### PR DESCRIPTION
## Summary
- add the Smallstep Helm repo before chart-releaser packages charts
- unblock release packaging for spiffe-step-ssh after the spire-lib dependent releases

## Testing
- inspected failing release job log for run 27070870757 / job 79899775927
- verified the failure was chart-releaser packaging charts/spiffe-step-ssh without the smallstep repo configured
