### PR TITLE
Fix release workflow path trigger

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - release
     paths:
-      - '.github/workflows/helm-release.yml'
+      - '.github/workflows/helm-release.yaml'
       - 'charts/**'
 
 jobs:


### PR DESCRIPTION
## Summary
- fix the release workflow path filter to point at helm-release.yaml
- ensure workflow-only changes to the release workflow actually trigger on pushes to release

## Testing
- inspected failing release workflow behavior after rerun
- verified the path filter was pointing at helm-release.yml while the actual workflow file is helm-release.yaml
