### PR TITLE
Bump spire-nested and dependent Helm Chart versions (minor)

### DIFF
--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "1.15.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-identity-exchange

* 96156f1d Update spire-identity-exchange version (#878)
* 0d689403 Bump spire to 1.15.2 (#875)
* daed3243 Fix the spire-identity-exchange stack support (#872)
* e44f006d Experimental support for spire-identity-exchange (#860)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-identity-exchange --bump patch
```
### Unreleased changes spire-lib

* 76873394 Enable easy plugin loading (#859)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-lib --bump patch
```
### Unreleased changes spire

* f548e058 Automatically label clusterspiffeids with their class name (#877)
* bf6b36c8 SPIRE Agent support for Broker API (#876)
* cc164bad Add EJBCA UpstreamAuthority plugin support to spire-server chart (#873)
* 0d689403 Bump spire to 1.15.2 (#875)
* af6533d7 We havent released 0.30.0 yet. Merge notes. (#869)
* e44f006d Experimental support for spire-identity-exchange (#860)
* 21bcece2 add config to allow disabling jwt svids (#864)
* 76873394 Enable easy plugin loading (#859)
* 4f8ac5af Configure jwt_issuer in SPIRE OIDC Provider (#829)
* 86c60b18 feat(spire-server): add terminationGracePeriodSeconds (#835)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --bump patch
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Release set

- spire-nested: 0.29.0 -> 0.30.0


## Changes in this release

* 0d689403 Bump spire to 1.15.2 (#875)
* e44f006d Experimental support for spire-identity-exchange (#860)
* 459cf8ff Add default labels to child-servers clusterSPIFFEIDs for external-root-spire-server-full (#866)
