### PR TITLE
Wire unsupportedBuiltInPlugins through to NodeAttestor

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -197,7 +197,7 @@ plugins:
 {{- end }}
 {{- end }}
 
-  {{- if or .Values.nodeAttestor.k8sPSAT.enabled .Values.nodeAttestor.externalK8sPSAT.enabled .Values.nodeAttestor.joinToken.enabled .Values.nodeAttestor.httpChallenge.enabled .Values.nodeAttestor.tpmDirect.enabled .Values.nodeAttestor.awsIID.enabled .Values.nodeAttestor.gcpIIT.enabled .Values.nodeAttestor.x509POP.enabled .Values.spireIdentityExchange.enabled }}
+  {{- if or .Values.nodeAttestor.k8sPSAT.enabled .Values.nodeAttestor.externalK8sPSAT.enabled .Values.nodeAttestor.joinToken.enabled .Values.nodeAttestor.httpChallenge.enabled .Values.nodeAttestor.tpmDirect.enabled .Values.nodeAttestor.awsIID.enabled .Values.nodeAttestor.gcpIIT.enabled .Values.nodeAttestor.x509POP.enabled .Values.spireIdentityExchange.enabled .Values.unsupportedBuiltInPlugins.nodeAttestor }}
   NodeAttestor:
   {{- $clusters := default .Values.kubeConfigs .Values.nodeAttestor.externalK8sPSAT.clusters }}
   {{- if or (eq (.Values.nodeAttestor.k8sPSAT.enabled | toString) "true") (and (eq (.Values.nodeAttestor.externalK8sPSAT.enabled | toString) "true") (gt (len $clusters) 0)) }}
@@ -345,6 +345,9 @@ plugins:
         {{- end }}
   {{- end }}
   {{- end }}
+{{- if .Values.unsupportedBuiltInPlugins.nodeAttestor }}
+  {{- .Values.unsupportedBuiltInPlugins.nodeAttestor | toYaml | nindent 4 }}
+{{- end }}
   {{- end }}
 
   {{- with .Values.keyManager.disk }}


### PR DESCRIPTION
## Summary
- NodeAttestor gets the same unsupportedBuiltInPlugins passthrough KeyManager already has
- Lets built-in NodeAttestor plugins the chart hasn't added structured values for yet (e.g. azure_msi) be configured today, per the existing comment on unsupportedBuiltInPlugins.nodeAttestor inviting this
- No values.yaml change needed - the placeholder already exists
- No Chart.yaml version bump per CONTRIBUTING.md (maintainers handle releases)

## Test plan
- [x] helm lint charts/spire
- [x] helm template charts/spire (default values) - NodeAttestor: does not render, byte-identical diff against pre-change output
- [x] helm template charts/spire -f <values setting unsupportedBuiltInPlugins.nodeAttestor.azure_msi...> - renders correctly nested under NodeAttestor:
- [x] Deployed to a live EKS cluster running spire-server - azure_msi plugin loads successfully alongside aws_iid/join_token/k8s_psat with no errors, server healthy