### PR TITLE
Add ca_bundle_path/ca_bundle_paths support to x509pop NodeAttestor

### DIFF
--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -282,7 +282,16 @@ plugins:
     x509pop:
       plugin_data:
         mode: {{ .mode }}
+        {{- if eq .mode "spiffe" }}
         spiffe_prefix: {{ include "spire-server.identity-exchange-spiffe-prefix" $root | quote }}
+        {{- end }}
+        {{- if ne .caBundlePath "" }}
+        ca_bundle_path: {{ .caBundlePath | quote }}
+        {{- end }}
+        {{- if not (empty .caBundlePaths) }}
+        ca_bundle_paths:
+          {{ toYaml .caBundlePaths | nindent 10 }}
+        {{- end }}
         max_intermediates: {{ .maxIntermediates }}
         max_rsa_key_size: {{ .maxRSAKeySize }}
         {{- $cn := "" }}

--- a/charts/spire/charts/spire-server/values.yaml
+++ b/charts/spire/charts/spire-server/values.yaml
@@ -1195,10 +1195,14 @@ nodeAttestor:
   x509POP:
     ## @param nodeAttestor.x509POP.enabled Enable the x509_popg node attestor
     enabled: false
-    ## @param nodeAttestor.x509POP.mode What mode to set the plugin to. Currently only spiffe mode is supported
+    ## @param nodeAttestor.x509POP.mode What mode to set the plugin to. "spiffe" uses the spire-identity-exchange flow (spiffePrefix below); "external_pki" verifies certificates against caBundlePath/caBundlePaths instead
     mode: spiffe
     ## @param nodeAttestor.x509POP.spiffePrefix What prefix to use when mode is spiffe
     spiffePrefix: "/spire-exchange/k8s${HELM_ADD_CLUSTER_NAME}/"
+    ## @param nodeAttestor.x509POP.caBundlePath Path to a single trusted CA bundle file on disk, used when mode is external_pki. Mutually exclusive with caBundlePaths - use this for a single file
+    caBundlePath: ""
+    ## @param nodeAttestor.x509POP.caBundlePaths [array] Paths to multiple trusted CA bundle files on disk, used when mode is external_pki. Mutually exclusive with caBundlePath - use this when CA certificates span more than one file
+    caBundlePaths: []
     ## @param nodeAttestor.x509POP.agentPathTemplate Override the default agent path template
     agentPathTemplate: ""
     ## @param nodeAttestor.x509POP.maxIntermediates Maximum number of intermediate certificates allowed in the certificate chain


### PR DESCRIPTION
## Summary
- x509pop's structured values only ever supported mode=spiffe (spire-identity-exchange flow) - mode=external_pki has no way to configure ca_bundle_path/ca_bundle_paths, both required by SPIRE's own x509pop plugin for that mode (see https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_x509pop.md)
- Adds nodeAttestor.x509POP.caBundlePath (string) and caBundlePaths (array) values, rendered only when set
- spiffe_prefix is now only rendered when mode=spiffe (previously rendered unconditionally, which meant it was emitted even for external_pki configs where it isn't used)
- No Chart.yaml version bump per CONTRIBUTING.md (maintainers handle releases)

## Test plan
- [x] helm template charts/spire (default values) - byte-identical diff against pre-change output
- [x] helm template charts/spire -f <values setting mode=external_pki, caBundlePaths=[...]> - ca_bundle_paths renders correctly, spiffe_prefix correctly omitted
- [x] helm template charts/spire -f <values setting mode=external_pki, caBundlePath=...> - ca_bundle_path (singular) renders correctly