### PR TITLE
Bump spire-lib Helm Chart version from 0.2.0 to 0.3.0

### DIFF
--- a/charts/spiffe-step-ssh/Chart.yaml
+++ b/charts/spiffe-step-ssh/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -30,7 +30,7 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.2.0
+    version: 0.3.0
   - name: step-certificates
     alias: step
     repository: https://smallstep.github.io/helm-charts/

--- a/charts/spire-ha-agent/Chart.yaml
+++ b/charts/spire-ha-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-ha-agent
 description: A Helm chart to install the SPIRE HA agent.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.2.0"
 keywords: ["spiffe", "spire-ha-agent"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-ha-agent
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.2.0
+    version: 0.3.0

--- a/charts/spire-identity-exchange/Chart.lock
+++ b/charts/spire-identity-exchange/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../spire-lib
   version: 0.3.0
 digest: sha256:b09e1da391c6df954369ee679f0757522fb39afe9a8e6bdc77c25d048fb30340
-generated: "2026-07-31T15:54:04.16488-07:00"
+generated: "2026-07-31T15:54:04.232401-07:00"

--- a/charts/spire-identity-exchange/Chart.yaml
+++ b/charts/spire-identity-exchange/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-identity-exchange
 description: A Helm chart to install the SPIRE Identity Exchange.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.3.0"
 keywords: ["spiffe", "spire", "identity exchange"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-identity-exchange
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.2.0
+    version: 0.3.0

--- a/charts/spire-lib/Chart.yaml
+++ b/charts/spire-lib/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-lib
 description: A library of helper templates for SPIRE charts.
 type: library
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"
 keywords: ["spiffe", "spire", "library"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-lib

--- a/charts/spire-lib/README.md
+++ b/charts/spire-lib/README.md
@@ -7,7 +7,7 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 ```yaml
 dependencies:
   - name: spire-lib
-    version: 0.2.0
+    version: 0.3.0
     repository: https://spiffe.github.io/helm-charts-hardened/
 ```
 

--- a/charts/spire-nested/Chart.lock
+++ b/charts/spire-nested/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.2.0
+  version: 0.3.0
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -43,6 +43,21 @@ dependencies:
   version: 0.1.0
 - name: spire-ha-agent
   repository: file://../spire-ha-agent
+  version: 0.3.0
+- name: spire-server
+  repository: file://../spire/charts/spire-server
+  version: 0.1.0
+- name: spire-agent
+  repository: file://../spire/charts/spire-agent
+  version: 0.1.0
+- name: spiffe-csi-driver
+  repository: file://../spire/charts/spiffe-csi-driver
+  version: 0.1.0
+- name: spiffe-csi-driver
+  repository: file://../spire/charts/spiffe-csi-driver
+  version: 0.1.0
+- name: spire-identity-exchange
+  repository: file://../spire-identity-exchange
   version: 0.2.0
 - name: spire-server
   repository: file://../spire/charts/spire-server
@@ -58,21 +73,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.1.0
-- name: spire-server
-  repository: file://../spire/charts/spire-server
-  version: 0.1.0
-- name: spire-agent
-  repository: file://../spire/charts/spire-agent
-  version: 0.1.0
-- name: spiffe-csi-driver
-  repository: file://../spire/charts/spiffe-csi-driver
-  version: 0.1.0
-- name: spiffe-csi-driver
-  repository: file://../spire/charts/spiffe-csi-driver
-  version: 0.1.0
-- name: spire-identity-exchange
-  repository: file://../spire-identity-exchange
-  version: 0.1.0
-digest: sha256:418e807bf7ff9504d000e3d1bc581faf83c91e0792e05ec7c11aaaa2cb54caf4
-generated: "2026-06-30T07:46:43.45713065-07:00"
+  version: 0.2.0
+digest: sha256:edf96a8d833dffffc31f0bfdd400ced75f0cf1868e2711a1cd72f51d6f099621
+generated: "2026-07-31T15:54:04.390913-07:00"

--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "1.15.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -23,7 +23,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.2.0
+    version: 0.3.0
   - name: spire-server
     alias: root-spire-server
     condition: root-spire-server.enabled
@@ -121,7 +121,7 @@ dependencies:
       - haAgentCommon
   - name: spire-ha-agent
     repository: file://../spire-ha-agent
-    version: 0.2.0
+    version: 0.3.0
     condition: spire-ha-agent.enabled
     tags:
       - haAgentCommon
@@ -157,7 +157,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-a
     condition: spire-identity-exchange-bottom-turtle-ha-a.enabled
     repository: file://../spire-identity-exchange
-    version: 0.1.0
+    version: 0.2.0
     tags:
       - bottomTurtleHAA
   - name: spire-server
@@ -192,7 +192,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-b
     condition: spire-identity-exchange-bottom-turtle-ha-b.enabled
     repository: file://../spire-identity-exchange
-    version: 0.1.0
+    version: 0.2.0
     tags:
       - bottomTurtleHAB
 annotations:

--- a/charts/spire/Chart.lock
+++ b/charts/spire/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.2.0
+  version: 0.3.0
 - name: spire-server
   repository: file://./charts/spire-server
   version: 0.1.0
@@ -34,6 +34,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.1.0
-digest: sha256:38b85a4bf147cc86a432ac32dfd3473e27efc6b6a3c1563340444bbe049a4746
-generated: "2026-06-27T10:53:07.840372246-07:00"
+  version: 0.2.0
+digest: sha256:5bd67eff208fb2918e03b52ab9ac5b2802558106d72a4e4ac94034a1b387c613
+generated: "2026-07-31T15:54:04.019458-07:00"

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "1.14.5"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -25,7 +25,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.2.0
+    version: 0.3.0
   - name: spire-server
     condition: spire-server.enabled
     repository: file://./charts/spire-server
@@ -71,7 +71,7 @@ dependencies:
   - name: spire-identity-exchange
     condition: spire-identity-exchange.enabled
     repository: file://../spire-identity-exchange
-    version: 0.1.0
+    version: 0.2.0
 annotations:
   org.opencontainers.image.source: https://github.com/spiffe/helm-charts-hardened
   artifacthub.io/category: security


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spiffe-step-ssh

* d84c1ad2 Bump spire-lib and dependent Helm Chart versions (minor)
* 3cfefb72 Gateway api support (#890)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spiffe-step-ssh --bump patch
```
### Unreleased changes spire-crds

* c0bee5ee Upgrade the spire-controller-manager (#896)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-crds --bump patch
```
### Unreleased changes spire-ha-agent

* d84c1ad2 Bump spire-lib and dependent Helm Chart versions (minor)
* f4c7df23 Add broker suport to the spire-ha-agent (#884)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-ha-agent --bump patch
```
### Unreleased changes spire-identity-exchange

* d84c1ad2 Bump spire-lib and dependent Helm Chart versions (minor)
* 3cfefb72 Gateway api support (#890)
* 96156f1d Update spire-identity-exchange version (#878)
* 0d689403 Bump spire to 1.15.2 (#875)
* daed3243 Fix the spire-identity-exchange stack support (#872)
* e44f006d Experimental support for spire-identity-exchange (#860)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-identity-exchange --bump patch
```
### Unreleased changes spire-nested

* d84c1ad2 Bump spire-lib and dependent Helm Chart versions (minor)
* f4c7df23 Add broker suport to the spire-ha-agent (#884)
* 0d689403 Bump spire to 1.15.2 (#875)
* e44f006d Experimental support for spire-identity-exchange (#860)
* 459cf8ff Add default labels to child-servers clusterSPIFFEIDs for external-root-spire-server-full (#866)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --bump patch
```
### Unreleased changes spire

* d84c1ad2 Bump spire-lib and dependent Helm Chart versions (minor)
* 3cfefb72 Gateway api support (#890)
* c0bee5ee Upgrade the spire-controller-manager (#896)
* 203183f7 Add externalSecret support to spire-server kubeConfigs (#889)
* 952cbedb Broker updates (#882)
* f548e058 Automatically label clusterspiffeids with their class name (#877)
* bf6b36c8 SPIRE Agent support for Broker API (#876)
* cc164bad Add EJBCA UpstreamAuthority plugin support to spire-server chart (#873)
* 0d689403 Bump spire to 1.15.2 (#875)
* af6533d7 We havent released 0.30.0 yet. Merge notes. (#869)
* e44f006d Experimental support for spire-identity-exchange (#860)
* 21bcece2 add config to allow disabling jwt svids (#864)
* 76873394 Enable easy plugin loading (#859)
* 4f8ac5af Configure jwt_issuer in SPIRE OIDC Provider (#829)
* 86c60b18 feat(spire-server): add terminationGracePeriodSeconds (#835)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --bump patch
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Release set

- spire-lib: 0.2.0 -> 0.3.0
- spiffe-step-ssh: 0.2.0 -> 0.3.0
- spire: 0.29.0 -> 0.30.0
- spire-ha-agent: 0.2.0 -> 0.3.0
- spire-nested: 0.29.0 -> 0.30.0
- spire-identity-exchange: 0.1.0 -> 0.2.0

## Changes in this release

* 3cfefb72 Gateway api support (#890)
* 76873394 Enable easy plugin loading (#859)
