### PR TITLE
fix(spire-agent): suffix spire-config ConfigMap name per agent profile

### DIFF
--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -473,7 +473,7 @@ spec:
       volumes:
         - name: spire-config
           configMap:
-            name: {{ include "spire-agent.fullname" . }}
+            name: {{ printf "%s%s" (include "spire-agent.fullname" .) $nameSuffix | quote }}
         {{- if .Values.keyManager.disk.enabled }}
         - name: spire-key-manager
           {{- if eq .Values.keyManager.disk.mode "hostPath" }}


### PR DESCRIPTION
Fixes #912

## What
The `spire-agent` DaemonSet's `spire-config` volume (which mounts `agent.conf`) is hardcoded to the default profile's ConfigMap name, unlike every other per-profile resource in this template (the profile's own ConfigMap, the trust-bundle volume, the DaemonSet name itself), which all correctly append `$nameSuffix`.

```diff
-            name: {{ include "spire-agent.fullname" . }}
+            name: {{ printf "%s%s" (include "spire-agent.fullname" .) $nameSuffix | quote }}
```

## Why
Any `spire-agent.agents.<name>` additional profile silently mounts the default profile's `agent.conf` instead of its own — whatever that profile's config actually sets (`nodeAttestor`, `workloadAttestors`, `customPlugins`, socket paths, anything) is never read, since the profile's own correctly-rendered ConfigMap is never mounted anywhere. This is independent of what a given profile's config contains — it breaks the multi-agent feature generally, for any profile whose config differs from the default.

Found this running a second profile with different `workloadAttestors.k8s` config than the default. The config rendered correctly in the ConfigMap but never took effect at runtime. Confirmed via live pod spec inspection that the profile's DaemonSet was mounting `spire-agent` (default), not `spire-agent-<profile>`.

## Testing
- `helm template` confirms the additional profile's DaemonSet now references its own correctly-suffixed ConfigMap, matching the DaemonSet name and the trust-bundle volume's existing (already-correct) behavior.
- No `Chart.yaml`/`values.yaml` changes, so no README regen needed.
- Verified against a real cluster running this chart with a second agent profile — the profile-specific config is now actually read after this fix.