### PR TITLE
Bump spire-crds Helm Chart version from 0.6.0 to 0.6.1

### DIFF
--- a/charts/spire-crds/Chart.yaml
+++ b/charts/spire-crds/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the Spire CRDS
 
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.0.1"
 keywords: ["spire-crds"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire

--- a/charts/spire-crds/README.md
+++ b/charts/spire-crds/README.md
@@ -1,6 +1,6 @@
 # spire-crds
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart to install the SPIRE CRDS.
 


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spire-ha-agent

* b47ab6c1 README.md version match check (#916)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-ha-agent --bump patch
```
### Unreleased changes spire-identity-exchange

* 8a28a1b9 Update spire to 1.15.3 (#926)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-identity-exchange --bump patch
```
### Unreleased changes spire-lib

* ab5e5d86 fix(spiffe-oidc-discovery-provider): run under restricted PSA/SCC on OpenShift (#920)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-lib --bump patch
```
### Unreleased changes spire-nested

* 8a28a1b9 Update spire to 1.15.3 (#926)
* b47ab6c1 README.md version match check (#916)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --bump patch
```
### Unreleased changes spire

* 8a28a1b9 Update spire to 1.15.3 (#926)
* b47ab6c1 README.md version match check (#916)
* 27026e46 fix(spire): preserve webhook order in patch hooks (#918)
* 1ce42d58 fix(spire-server): support postgres TLS client-certificate (passwordless) auth (#922)
* ab5e5d86 fix(spiffe-oidc-discovery-provider): run under restricted PSA/SCC on OpenShift (#920)
* 0726faa0 :sparkles: add topologySpreadConstraints support to OIDC discovery provider (#925)
* f1dddf2e feat: add first-class support for gcp_cas UpstreamAuthority plugin (#914)
* 59bb8a77 Allow sqlite3 in memory when kind is deployment (#923)
* e46ad159 Make spire-server rollout strategy configurable (#924)
* b60c222c fix(spire-agent): suffix spire-config ConfigMap name per agent profile (#913)
* 648e0e45 Add JWT-SVID exec-auth source for kubeConfigs entries (#907)
* a481bab3 Add PodDisruptionBudget support to spire-server (#909)
* 80705999 feat(spire-server): support x509pop externalPKI ca bundle (#908)
* 890ada3e Add externalTrafficPolicy support for spire-server LoadBalancer service (#906)
* 58dab12e Include filterByClassName setting for controller manager (#905)
* ecf6324d Make the external server's downstream RBAC subject configurable (#899)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --bump patch
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Release set

- spire-crds: 0.6.0 -> 0.6.1


## Changes in this release

* b47ab6c1 README.md version match check (#916)
