### PR TITLE
Bump spire-lib Helm Chart version from 0.3.0 to 0.3.1

### DIFF
--- a/charts/spiffe-step-ssh/Chart.lock
+++ b/charts/spiffe-step-ssh/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.0
+  version: 0.3.1
 - name: step-certificates
   repository: https://smallstep.github.io/helm-charts/
   version: 1.27.4
-digest: sha256:b41dcd4ef1a70026a96cbd6b704ae22b7c62c139d3cf699ac746366658698825
-generated: "2026-07-31T16:55:06.703514-07:00"
+digest: sha256:11d3748666d0c9aa04a77a01ed3cde99553aae715bc9f00b311247e6a9c6ee91
+generated: "2026-08-21T14:41:49.31784-07:00"

--- a/charts/spiffe-step-ssh/Chart.yaml
+++ b/charts/spiffe-step-ssh/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -30,7 +30,7 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.0
+    version: 0.3.1
   - name: step-certificates
     alias: step
     repository: https://smallstep.github.io/helm-charts/

--- a/charts/spire-ha-agent/Chart.lock
+++ b/charts/spire-ha-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.0
-digest: sha256:b09e1da391c6df954369ee679f0757522fb39afe9a8e6bdc77c25d048fb30340
-generated: "2026-07-31T16:55:07.148848-07:00"
+  version: 0.3.1
+digest: sha256:fd4f15738349c83d9a1c60a1529ecc5cb8df6ecd9af21176df54f61f40d8973e
+generated: "2026-08-21T14:41:50.554693-07:00"

--- a/charts/spire-ha-agent/Chart.yaml
+++ b/charts/spire-ha-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-ha-agent
 description: A Helm chart to install the SPIRE HA agent.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.3.0"
 keywords: ["spiffe", "spire-ha-agent"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-ha-agent
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.0
+    version: 0.3.1

--- a/charts/spire-ha-agent/README.md
+++ b/charts/spire-ha-agent/README.md
@@ -1,6 +1,6 @@
 # spire-ha-agent
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE HA agent.
 

--- a/charts/spire-identity-exchange/Chart.lock
+++ b/charts/spire-identity-exchange/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.0
-digest: sha256:b09e1da391c6df954369ee679f0757522fb39afe9a8e6bdc77c25d048fb30340
-generated: "2026-07-31T16:55:07.22031-07:00"
+  version: 0.3.1
+digest: sha256:fd4f15738349c83d9a1c60a1529ecc5cb8df6ecd9af21176df54f61f40d8973e
+generated: "2026-08-21T14:41:50.632935-07:00"

--- a/charts/spire-identity-exchange/Chart.yaml
+++ b/charts/spire-identity-exchange/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-identity-exchange
 description: A Helm chart to install the SPIRE Identity Exchange.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.5.0"
 keywords: ["spiffe", "spire", "identity exchange"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-identity-exchange
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.0
+    version: 0.3.1

--- a/charts/spire-identity-exchange/README.md
+++ b/charts/spire-identity-exchange/README.md
@@ -1,6 +1,6 @@
 # spire-identity-exchange
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE Identity Exchange.
 

--- a/charts/spire-lib/Chart.yaml
+++ b/charts/spire-lib/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-lib
 description: A library of helper templates for SPIRE charts.
 type: library
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.1.0"
 keywords: ["spiffe", "spire", "library"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-lib

--- a/charts/spire-lib/README.md
+++ b/charts/spire-lib/README.md
@@ -7,7 +7,7 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 ```yaml
 dependencies:
   - name: spire-lib
-    version: 0.3.0
+    version: 0.3.1
     repository: https://spiffe.github.io/helm-charts-hardened/
 ```
 

--- a/charts/spire-nested/Chart.lock
+++ b/charts/spire-nested/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.0
+  version: 0.3.1
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -43,7 +43,7 @@ dependencies:
   version: 0.1.0
 - name: spire-ha-agent
   repository: file://../spire-ha-agent
-  version: 0.3.0
+  version: 0.3.1
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -58,7 +58,7 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.0
+  version: 0.2.1
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -73,6 +73,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.0
-digest: sha256:edf96a8d833dffffc31f0bfdd400ced75f0cf1868e2711a1cd72f51d6f099621
-generated: "2026-07-31T16:55:07.391766-07:00"
+  version: 0.2.1
+digest: sha256:bd10aa2236190a29056e5b32300d16883bc01635d2446a32c91ead2639b98f1d
+generated: "2026-08-21T14:41:50.936953-07:00"

--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.30.0
+version: 0.30.1
 appVersion: "1.15.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -23,7 +23,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.0
+    version: 0.3.1
   - name: spire-server
     alias: root-spire-server
     condition: root-spire-server.enabled
@@ -121,7 +121,7 @@ dependencies:
       - haAgentCommon
   - name: spire-ha-agent
     repository: file://../spire-ha-agent
-    version: 0.3.0
+    version: 0.3.1
     condition: spire-ha-agent.enabled
     tags:
       - haAgentCommon
@@ -157,7 +157,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-a
     condition: spire-identity-exchange-bottom-turtle-ha-a.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.0
+    version: 0.2.1
     tags:
       - bottomTurtleHAA
   - name: spire-server
@@ -192,7 +192,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-b
     condition: spire-identity-exchange-bottom-turtle-ha-b.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.0
+    version: 0.2.1
     tags:
       - bottomTurtleHAB
 annotations:

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
+![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.

--- a/charts/spire/Chart.lock
+++ b/charts/spire/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.0
+  version: 0.3.1
 - name: spire-server
   repository: file://./charts/spire-server
   version: 0.1.0
@@ -34,6 +34,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.0
-digest: sha256:5bd67eff208fb2918e03b52ab9ac5b2802558106d72a4e4ac94034a1b387c613
-generated: "2026-07-31T16:55:07.012434-07:00"
+  version: 0.2.1
+digest: sha256:2916c04b61f4813e2e107b84a2168fdf141c67086658e1adbb9501b8425cd6e1
+generated: "2026-08-21T14:41:50.353186-07:00"

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.30.0
+version: 0.30.1
 appVersion: "1.15.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -25,7 +25,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.0
+    version: 0.3.1
   - name: spire-server
     condition: spire-server.enabled
     repository: file://./charts/spire-server
@@ -71,7 +71,7 @@ dependencies:
   - name: spire-identity-exchange
     condition: spire-identity-exchange.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.0
+    version: 0.2.1
 annotations:
   org.opencontainers.image.source: https://github.com/spiffe/helm-charts-hardened
   artifacthub.io/category: security

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
+![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.

### Unreleased changes spiffe-step-ssh

* 67b8190d Bump spire-lib and dependent Helm Chart versions (patch)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spiffe-step-ssh --bump patch
```
### Unreleased changes spire-crds

* b47ab6c1 README.md version match check (#916)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-crds --bump patch
```
### Unreleased changes spire-ha-agent

* 67b8190d Bump spire-lib and dependent Helm Chart versions (patch)
* b47ab6c1 README.md version match check (#916)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-ha-agent --bump patch
```
### Unreleased changes spire-identity-exchange

* 67b8190d Bump spire-lib and dependent Helm Chart versions (patch)
* 8a28a1b9 Update spire to 1.15.3 (#926)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-identity-exchange --bump patch
```
### Unreleased changes spire-nested

* 67b8190d Bump spire-lib and dependent Helm Chart versions (patch)
* 8a28a1b9 Update spire to 1.15.3 (#926)
* b47ab6c1 README.md version match check (#916)
* 07ba722d Update spire-identity-exchange for 0.4.0 (#900)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire-nested --bump patch
```
### Unreleased changes spire

* 67b8190d Bump spire-lib and dependent Helm Chart versions (patch)
* 8a28a1b9 Update spire to 1.15.3 (#926)
* b47ab6c1 README.md version match check (#916)
* 27026e46 fix(spire): preserve webhook order in patch hooks (#918)
* 1ce42d58 fix(spire-server): support postgres TLS client-certificate (passwordless) auth (#922)
* ab5e5d86 fix(spiffe-oidc-discovery-provider): run under restricted PSA/SCC on OpenShift (#920)
* 0726faa0 :sparkles: add topologySpreadConstraints support to OIDC discovery provider (#925)
* f1dddf2e feat: add first-class support for gcp_cas UpstreamAuthority plugin (#914)
* 59bb8a77 Allow sqlite3 in memory when kind is deployment (#923)
* e46ad159 Make spire-server rollout strategy configurable (#924)
* b60c222c fix(spire-agent): suffix spire-config ConfigMap name per agent profile (#913)
* 648e0e45 Add JWT-SVID exec-auth source for kubeConfigs entries (#907)
* a481bab3 Add PodDisruptionBudget support to spire-server (#909)
* 80705999 feat(spire-server): support x509pop externalPKI ca bundle (#908)
* 890ada3e Add externalTrafficPolicy support for spire-server LoadBalancer service (#906)
* 58dab12e Include filterByClassName setting for controller manager (#905)
* ecf6324d Make the external server's downstream RBAC subject configurable (#899)

Please ensure you bump above charts as well before merging main into the release branch.

```shell
./release-chart.sh --chart spire --bump patch
```

> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Release set

- spire-lib: 0.3.0 -> 0.3.1
- spiffe-step-ssh: 0.3.0 -> 0.3.1
- spire: 0.30.0 -> 0.30.1
- spire-ha-agent: 0.3.0 -> 0.3.1
- spire-nested: 0.30.0 -> 0.30.1
- spire-identity-exchange: 0.2.0 -> 0.2.1

## Changes in this release

* ab5e5d86 fix(spiffe-oidc-discovery-provider): run under restricted PSA/SCC on OpenShift (#920)
