### PR TITLE
fix(spire-server): scrape controller-manager metrics port (pm-cm)

### DIFF
--- a/charts/spire/charts/spire-server/templates/_controller-manager-container.tpl
+++ b/charts/spire/charts/spire-server/templates/_controller-manager-container.tpl
@@ -189,3 +189,60 @@ Auto-generation preserves trailing numbers from cluster names or uses hash for u
     {{- toYaml .Values.extraVolumeMounts | nindent 4 }}
     {{- end }}
 {{- end }}
+{{/*
+Returns the list of controller-manager prometheus port names (one per line), matching the
+port names emitted by "spire-controller-manager.container" above. Used by the PodMonitor so
+its scrape endpoints stay in sync with the actual container ports. The suffix logic here MUST
+mirror the "spire-controller-manager.containers" iteration and its portSuffix computation.
+Emits nothing when the controller manager is disabled or prometheus telemetry is off.
+*/}}
+{{- define "spire-controller-manager.prometheus-port-names" }}
+{{-   if or (dig "telemetry" "prometheus" "enabled" .Values.telemetry.prometheus.enabled .Values.global) (and (dig "spire" "recommendations" "enabled" false .Values.global) (dig "spire" "recommendations" "prometheus" true .Values.global)) }}
+{{-     if eq (.Values.controllerManager.enabled | toString) "true" }}
+{{-       $pmName := "" }}
+{{-       if hasKey .Values.controllerManager "prometheusPortName" }}
+{{-         $pmName = .Values.controllerManager.prometheusPortName }}
+{{-       end }}
+{{-       if eq $pmName "" }}
+{{-         $pmName = "pm-cm" }}
+{{-       end }}
+- {{ $pmName }}
+{{-     end }}
+{{-     if .Values.externalControllerManagers.enabled }}
+{{-       $clusters := default .Values.kubeConfigs .Values.externalControllerManagers.clusters }}
+{{-       range $name, $_ := $clusters }}
+{{-         $root := $ }}
+{{-         $clusterSettings := dict }}
+{{-         if hasKey $root.Values.externalControllerManagers.clusters $name }}
+{{-           $clusterSettings = index $root.Values.externalControllerManagers.clusters $name }}
+{{-         end }}
+{{-         $portSuffix := printf "-%s" $name }}
+{{-         $prometheusPortName := "" }}
+{{-         if hasKey $clusterSettings "prometheusPortName" }}
+{{-           $prometheusPortName = $clusterSettings.prometheusPortName }}
+{{-         end }}
+{{-         if eq $prometheusPortName "" }}
+{{-           if gt (len $name) 9 }}
+{{-             $numberMatch := regexFind "[-]?[0-9]{1,2}$" $name }}
+{{-             if $numberMatch }}
+{{-               $numLen := len $numberMatch }}
+{{-               $baseLen := sub (len $name) $numLen | int }}
+{{-               $baseName := substr 0 $baseLen $name }}
+{{-               if not (hasPrefix "-" $numberMatch) }}
+{{-                 $numberMatch = printf "-%s" $numberMatch }}
+{{-               end }}
+{{-               $maxBase := sub 9 (len $numberMatch) | int }}
+{{-               $baseName = $baseName | trunc $maxBase | trimSuffix "-" }}
+{{-               $portSuffix = printf "-%s%s" $baseName $numberMatch }}
+{{-             else }}
+{{-               $hash := sha256sum $name | trunc 3 }}
+{{-               $portSuffix = printf "-%s-%s" ($name | trunc 5 | trimSuffix "-") $hash }}
+{{-             end }}
+{{-           end }}
+{{-           $prometheusPortName = printf "pm-cm%s" $portSuffix }}
+{{-         end }}
+- {{ $prometheusPortName }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/podmonitor.yaml
+++ b/charts/spire/charts/spire-server/templates/podmonitor.yaml
@@ -21,7 +21,9 @@ spec:
       {{- include "spire-server.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     - port: prom
-    - port: prom-cm
+    {{- range (include "spire-controller-manager.prometheus-port-names" . | fromYamlArray) }}
+    - port: {{ . }}
+    {{- end }}
   {{- if ne $namespace $podNamespace }}
   namespaceSelector:
     kubernetes.io/metadata.name: {{ $podNamespace }}

--- a/tests/unit/spire_test.go
+++ b/tests/unit/spire_test.go
@@ -90,12 +90,12 @@ func ValueStringRender(chart *helmchart.Chart, values string) (map[string]string
 	testChart.Values = merged
 
 	var activeDeps []*helmchart.Chart
-        for _, dep := range testChart.Dependencies() {
-                if dep.Name() != "spire-identity-exchange" {
-                        activeDeps = append(activeDeps, dep)
-                }
-        }
-        testChart.SetDependencies(activeDeps...)
+	for _, dep := range testChart.Dependencies() {
+		if dep.Name() != "spire-identity-exchange" {
+			activeDeps = append(activeDeps, dep)
+		}
+	}
+	testChart.SetDependencies(activeDeps...)
 
 	ro := helmutil.ReleaseOptions{Name: "spire", Namespace: "spire-server", Revision: 1, IsUpgrade: false, IsInstall: true}
 	v, err = helmutil.ToRenderValues(&testChart, merged, ro, helmutil.DefaultCapabilities)
@@ -885,6 +885,68 @@ spire-server:
 			serverResource := objs["spire/charts/spire-server/templates/server-resource.yaml"]
 			Expect(serverResource).Should(ContainSubstring("name: RODBPW"))
 			Expect(serverResource).Should(ContainSubstring("name: my-ro-db-secret"))
+		})
+	})
+	Describe("spire-server.podMonitor.controllerManagerPorts", func() {
+		It("scrapes the controller-manager pm-cm port, not prom-cm", func() {
+			objs, err := ValueStringRender(chart, `
+spire-server:
+  telemetry:
+    prometheus:
+      enabled: true
+      podMonitor:
+        enabled: true
+  controllerManager:
+    enabled: true
+`)
+			Expect(err).Should(Succeed())
+			pm := objs["spire/charts/spire-server/templates/podmonitor.yaml"]
+			Expect(pm).Should(ContainSubstring("- port: prom"))
+			Expect(pm).Should(ContainSubstring("- port: pm-cm"))
+			Expect(pm).ShouldNot(ContainSubstring("prom-cm"))
+		})
+		It("scrapes each external controller-manager's suffixed pm-cm port", func() {
+			objs, err := ValueStringRender(chart, `
+spire-server:
+  telemetry:
+    prometheus:
+      enabled: true
+      podMonitor:
+        enabled: true
+  controllerManager:
+    enabled: true
+  externalControllerManagers:
+    enabled: true
+  kubeConfigs:
+    microserv:
+      externalSecret:
+        name: leaf-kc
+        key: kubeconfig
+`)
+			Expect(err).Should(Succeed())
+			pm := objs["spire/charts/spire-server/templates/podmonitor.yaml"]
+			serverResource := objs["spire/charts/spire-server/templates/server-resource.yaml"]
+			// The suffixed CM container port must exist and the PodMonitor must scrape it.
+			Expect(serverResource).Should(ContainSubstring("name: pm-cm-microserv"))
+			Expect(pm).Should(ContainSubstring("- port: pm-cm"))
+			Expect(pm).Should(ContainSubstring("- port: pm-cm-microserv"))
+		})
+		It("only scrapes the server port when the controller-manager is disabled", func() {
+			objs, err := ValueStringRender(chart, `
+spire-server:
+  telemetry:
+    prometheus:
+      enabled: true
+      podMonitor:
+        enabled: true
+  controllerManager:
+    enabled: false
+`)
+			Expect(err).Should(Succeed())
+			pm := objs["spire/charts/spire-server/templates/podmonitor.yaml"]
+			Expect(pm).Should(ContainSubstring("- port: prom"))
+			Expect(pm).ShouldNot(ContainSubstring("pm-cm"))
+			Expect(pm).ShouldNot(ContainSubstring("prom-cm"))
 		})
 	})
 })


### PR DESCRIPTION
## Problem
The spire-server `PodMonitor` hardcodes `- port: prom-cm`, but the controller-manager container exposes its Prometheus port as **`pm-cm`** (see `_controller-manager-container.tpl`, `printf "pm-cm%s" .portSuffix`). For external controller managers the port is suffixed per cluster (`pm-cm-<cluster>`, with numeric-preserving/hashed truncation for long names).

Because no pod exposes a `prom-cm` port, the controller-manager metrics (controller-runtime reconcile, workqueue, leader election, certwatcher, rest_client) are **never scraped** when `telemetry.prometheus.podMonitor.enabled=true`. Only the server's own `prom` (9988) endpoint is collected.

## Fix
- Add a `spire-controller-manager.prometheus-port-names` helper that returns the CM Prometheus port names, mirroring the exact iteration and `portSuffix` logic used by `spire-controller-manager.containers` (primary CM plus one entry per `externalControllerManagers`/`kubeConfigs` cluster). It is gated on the same telemetry/recommendations condition and honours `prometheusPortName` overrides.
- Rewrite the PodMonitor's `podMetricsEndpoints` to always scrape `prom` and then `range` over the helper, so scrape endpoints stay in sync with the actual container ports and no longer reference the non-existent `prom-cm`.

## Tests
Added unit tests in `tests/unit/spire_test.go`:
- single CM → PodMonitor scrapes `pm-cm`, not `prom-cm`;
- external CM (`kubeConfigs.microserv`) → PodMonitor scrapes both `pm-cm` and the suffixed `pm-cm-microserv` (matching the rendered container port);
- CM disabled → only the server `prom` port is scraped.

Verified with `helm template` (single, multi-cluster, and long-name hash-suffix cases) and `go test ./tests/unit` (51 passed).

## Impact
No values API change; behaviour only differs when the PodMonitor is enabled. Existing installs gain the previously-missing controller-manager metrics.