### PR TITLE
Bump spire-lib Helm Chart version from 0.3.1 to 0.3.2

### DIFF
--- a/charts/spiffe-step-ssh/Chart.lock
+++ b/charts/spiffe-step-ssh/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.1
+  version: 0.3.2
 - name: step-certificates
   repository: https://smallstep.github.io/helm-charts/
   version: 1.27.4
-digest: sha256:11d3748666d0c9aa04a77a01ed3cde99553aae715bc9f00b311247e6a9c6ee91
-generated: "2026-08-21T14:41:49.31784-07:00"
+digest: sha256:9b62d2daefc0199e874a43e80127cc1fd75486121d860bd36a5249978fde04ac
+generated: "2026-09-04T14:16:46.86151-07:00"

--- a/charts/spiffe-step-ssh/Chart.yaml
+++ b/charts/spiffe-step-ssh/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -30,7 +30,7 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.1
+    version: 0.3.2
   - name: step-certificates
     alias: step
     repository: https://smallstep.github.io/helm-charts/

--- a/charts/spire-ha-agent/Chart.lock
+++ b/charts/spire-ha-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.1
-digest: sha256:fd4f15738349c83d9a1c60a1529ecc5cb8df6ecd9af21176df54f61f40d8973e
-generated: "2026-08-21T14:41:50.554693-07:00"
+  version: 0.3.2
+digest: sha256:1360466b9040d3ec4947a299db81a6c1635f5b87042b73cf95c99c1badc4634f
+generated: "2026-09-04T14:16:48.082704-07:00"

--- a/charts/spire-ha-agent/Chart.yaml
+++ b/charts/spire-ha-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-ha-agent
 description: A Helm chart to install the SPIRE HA agent.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.5.0"
 keywords: ["spiffe", "spire-ha-agent"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-ha-agent
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.1
+    version: 0.3.2

--- a/charts/spire-ha-agent/README.md
+++ b/charts/spire-ha-agent/README.md
@@ -1,6 +1,6 @@
 # spire-ha-agent
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE HA agent.
 

--- a/charts/spire-identity-exchange/Chart.lock
+++ b/charts/spire-identity-exchange/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.1
-digest: sha256:fd4f15738349c83d9a1c60a1529ecc5cb8df6ecd9af21176df54f61f40d8973e
-generated: "2026-08-21T14:41:50.632935-07:00"
+  version: 0.3.2
+digest: sha256:1360466b9040d3ec4947a299db81a6c1635f5b87042b73cf95c99c1badc4634f
+generated: "2026-09-04T14:16:48.149156-07:00"

--- a/charts/spire-identity-exchange/Chart.yaml
+++ b/charts/spire-identity-exchange/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-identity-exchange
 description: A Helm chart to install the SPIRE Identity Exchange.
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "v0.5.0"
 keywords: ["spiffe", "spire", "identity exchange"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-identity-exchange
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.1
+    version: 0.3.2

--- a/charts/spire-identity-exchange/README.md
+++ b/charts/spire-identity-exchange/README.md
@@ -1,6 +1,6 @@
 # spire-identity-exchange
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
 
 A Helm chart to install the SPIRE Identity Exchange.
 

--- a/charts/spire-lib/Chart.yaml
+++ b/charts/spire-lib/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spire-lib
 description: A library of helper templates for SPIRE charts.
 type: library
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.1.0"
 keywords: ["spiffe", "spire", "library"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire-lib

--- a/charts/spire-lib/README.md
+++ b/charts/spire-lib/README.md
@@ -7,7 +7,7 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 ```yaml
 dependencies:
   - name: spire-lib
-    version: 0.3.1
+    version: 0.3.2
     repository: https://spiffe.github.io/helm-charts-hardened/
 ```
 

--- a/charts/spire-nested/Chart.lock
+++ b/charts/spire-nested/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.1
+  version: 0.3.2
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -43,7 +43,7 @@ dependencies:
   version: 0.1.0
 - name: spire-ha-agent
   repository: file://../spire-ha-agent
-  version: 0.3.1
+  version: 0.3.2
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -58,7 +58,7 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.1
+  version: 0.2.2
 - name: spire-server
   repository: file://../spire/charts/spire-server
   version: 0.1.0
@@ -73,6 +73,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.1
-digest: sha256:bd10aa2236190a29056e5b32300d16883bc01635d2446a32c91ead2639b98f1d
-generated: "2026-08-21T14:41:50.936953-07:00"
+  version: 0.2.2
+digest: sha256:b107601c95dca75c1bc8be08699d8051200fc3e83d12c392c1853936cffe74ce
+generated: "2026-09-04T14:16:48.37985-07:00"

--- a/charts/spire-nested/Chart.yaml
+++ b/charts/spire-nested/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.30.1
+version: 0.30.2
 appVersion: "1.15.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -23,7 +23,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.1
+    version: 0.3.2
   - name: spire-server
     alias: root-spire-server
     condition: root-spire-server.enabled
@@ -121,7 +121,7 @@ dependencies:
       - haAgentCommon
   - name: spire-ha-agent
     repository: file://../spire-ha-agent
-    version: 0.3.1
+    version: 0.3.2
     condition: spire-ha-agent.enabled
     tags:
       - haAgentCommon
@@ -157,7 +157,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-a
     condition: spire-identity-exchange-bottom-turtle-ha-a.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.1
+    version: 0.2.2
     tags:
       - bottomTurtleHAA
   - name: spire-server
@@ -192,7 +192,7 @@ dependencies:
     alias: spire-identity-exchange-bottom-turtle-ha-b
     condition: spire-identity-exchange-bottom-turtle-ha-b.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.1
+    version: 0.2.2
     tags:
       - bottomTurtleHAB
 annotations:

--- a/charts/spire-nested/README.md
+++ b/charts/spire-nested/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
+![Version: 0.30.2](https://img.shields.io/badge/Version-0.30.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.

--- a/charts/spire/Chart.lock
+++ b/charts/spire/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: spire-lib
   repository: file://../spire-lib
-  version: 0.3.1
+  version: 0.3.2
 - name: spire-server
   repository: file://./charts/spire-server
   version: 0.1.0
@@ -34,6 +34,6 @@ dependencies:
   version: 0.1.0
 - name: spire-identity-exchange
   repository: file://../spire-identity-exchange
-  version: 0.2.1
-digest: sha256:2916c04b61f4813e2e107b84a2168fdf141c67086658e1adbb9501b8425cd6e1
-generated: "2026-08-21T14:41:50.353186-07:00"
+  version: 0.2.2
+digest: sha256:f2df7c3ec6008984f9987f181764c4773a8d8d2b3786656170f0dc45fd20b9d2
+generated: "2026-09-04T14:16:47.91006-07:00"

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.
 
 type: application
-version: 0.30.1
+version: 0.30.2
 appVersion: "1.15.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/spiffe/helm-charts-hardened/tree/main/charts/spire
@@ -25,7 +25,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: spire-lib
     repository: file://../spire-lib
-    version: 0.3.1
+    version: 0.3.2
   - name: spire-server
     condition: spire-server.enabled
     repository: file://./charts/spire-server
@@ -71,7 +71,7 @@ dependencies:
   - name: spire-identity-exchange
     condition: spire-identity-exchange.enabled
     repository: file://../spire-identity-exchange
-    version: 0.2.1
+    version: 0.2.2
 annotations:
   org.opencontainers.image.source: https://github.com/spiffe/helm-charts-hardened
   artifacthub.io/category: security

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -1,6 +1,6 @@
 # spire
 
-![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
+![Version: 0.30.2](https://img.shields.io/badge/Version-0.30.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 
 A Helm chart for deploying the complete Spire stack including: spire-server, spire-agent, spiffe-csi-driver, spiffe-oidc-discovery-provider and spire-controller-manager.


### PR DESCRIPTION
Please review the below changelog to ensure this matches up with the semantic version being applied.

> [!Important]
> Before merging to the release branch, ensure all other changed charts also have their version number bumped.



> [!Note]
> **Maintainers** ensure to run following after merging this PR to trigger the release workflow:
>
> ```shell
> git checkout main
> git pull
> git checkout release
> git pull
> git merge main
> git push
> ```

## Release set

- spire-lib: 0.3.1 -> 0.3.2
- spiffe-step-ssh: 0.3.1 -> 0.3.2
- spire: 0.30.1 -> 0.30.2
- spire-ha-agent: 0.3.1 -> 0.3.2
- spire-nested: 0.30.1 -> 0.30.2
- spire-identity-exchange: 0.2.1 -> 0.2.2

## Changes in this release

* c6381219 feat(gateway): expose gatewayAPI.gateway.infrastructure passthrough (#939)
